### PR TITLE
adsprpc: PD tear down perf optimization

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -320,6 +320,7 @@ struct handle_list {
    pthread_mutex_t lmut;
 	pthread_mutex_t mut;
 	pthread_mutex_t init;
+	uint32_t rhzeroCount; /* To hold zero remote handle count */
 	uint32_t constCount;
 	uint32_t domainsCount;
 	uint32_t nondomainsCount;

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -320,7 +320,6 @@ struct handle_list {
    pthread_mutex_t lmut;
 	pthread_mutex_t mut;
 	pthread_mutex_t init;
-	uint32_t non_remotehandlecount; /* To hold non remote handle count */
 	uint32_t constCount;
 	uint32_t domainsCount;
 	uint32_t nondomainsCount;

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -320,7 +320,7 @@ struct handle_list {
    pthread_mutex_t lmut;
 	pthread_mutex_t mut;
 	pthread_mutex_t init;
-	uint32_t rhzeroCount; /* To hold zero remote handle count */
+	uint32_t non_remotehandlecount; /* To hold non remote handle count */
 	uint32_t constCount;
 	uint32_t domainsCount;
 	uint32_t nondomainsCount;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1841,14 +1841,16 @@ bail:
         domain_deinit(domain);
       }
     if (nErr != AEE_SUCCESS) {
-      if (is_process_exiting(domain))
+      if (is_process_exiting(domain)) {
         return 0;
-      if (0 == check_rpc_error(nErr))
+      }
+      if (0 == check_rpc_error(nErr)) {
         FARF(ERROR,
            "Error 0x%x: %s failed for handle 0x%" PRIx64
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].open_handle_count);
+      }
     } else {
        FARF(ALWAYS,
           "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1832,10 +1832,10 @@ int remote_handle64_close(remote_handle64 handle) {
     VERIFY(AEE_SUCCESS ==
            (nErr = remote_handle_close_domain(domain, (remote_handle)remote)));
   }
+  fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, handle, NULL);
+  FASTRPC_PUT_REF(domain);
 bail:
   if (nErr != AEE_EINVHANDLE && is_domain_valid(domain)) {
-     fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, handle, NULL);
-     FASTRPC_PUT_REF(domain);
     if (start_deinit) {
         hlist[domain].disable_exit_logs = 1;
         domain_deinit(domain);

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1638,9 +1638,8 @@ bail:
     pdname_uri = NULL;
   }
   if (nErr == AEE_ECONNRESET) {
-      if (!hlist[domain].refs && !hlist[domain].domainsCount &&
-        !hlist[domain].nondomainsCount) {
-    /* Close session if there are no open remote handles */
+      if (!hlist[domain].domainsCount && !hlist[domain].nondomainsCount) {
+      /* Close session if there are no open remote handles */
       hlist[domain].disable_exit_logs = 1;
       domain_deinit(domain);
     }
@@ -1818,14 +1817,12 @@ int remote_handle64_close(remote_handle64 handle) {
   set_thread_context(domain);
   /*
    * Terminate remote session if
-   *     1. there are no 'handle open' calls in progress AND
-   *     2. there are no open non-domain handles AND
-   *     3. there are no open multi-domain handles, OR
+   *     1. there are no open non-domain handles AND
+   *     2. there are no open multi-domain handles, OR
    *        only 1 multi-domain handle is open (for perf reason,
    *        skip closing of it)
    */
-  if (hlist[domain].refs <= 1 && hlist[domain].domainsCount <= 1 &&
-    !hlist[domain].nondomainsCount)
+  if (hlist[domain].domainsCount <= 1 && !hlist[domain].nondomainsCount)
     start_deinit = true;
   /*
    * If session termination is not initiated and the remote handle is valid,

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -860,7 +860,7 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
            (nErr = fastrpc_alloc_handle(domain, &hlist[domain].ql, h, local)));
    if (!h) {
       pthread_mutex_lock(&hlist[domain].lmut);
-      hlist[domain].rhzeroCount++;
+      hlist[domain].non_remotehandlecount++;
       pthread_mutex_unlock(&hlist[domain].lmut);
     } else if (IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
@@ -878,7 +878,7 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
            (nErr = fastrpc_free_handle(domain, &hlist[domain].ql, h)));
     if (!h) {
       pthread_mutex_lock(&hlist[domain].lmut);
-      hlist[domain].rhzeroCount--;
+      hlist[domain].non_remotehandlecount--;
       pthread_mutex_unlock(&hlist[domain].lmut);
     } else if (IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
@@ -1646,7 +1646,7 @@ bail:
     pdname_uri = NULL;
   }
   if (nErr == AEE_ECONNRESET) {
-    if (!hlist[domain].domainsCount && !hlist[domain].rhzeroCount && !hlist[domain].nondomainsCount) {
+    if (!hlist[domain].domainsCount && !hlist[domain].non_remotehandlecount && !hlist[domain].nondomainsCount) {
     /* Close session if there are no open remote handles */
       hlist[domain].disable_exit_logs = 1;
       domain_deinit(domain);
@@ -1830,7 +1830,7 @@ int remote_handle64_close(remote_handle64 handle) {
    *        only 1 multi-domain handle is open (for perf reason,
    *        skip closing of it)
    */
-  if ((hlist[domain].domainsCount + hlist[domain].rhzeroCount) <= 1 && !hlist[domain].nondomainsCount)
+  if ((hlist[domain].domainsCount + hlist[domain].non_remotehandlecount) <= 1 && !hlist[domain].nondomainsCount)
     start_deinit = true;
   /*
    * If session termination is not initiated and the remote handle is valid,

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1849,12 +1849,11 @@ bail:
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].domainsCount);
-      } else {
+      } else 
        FARF(ALWAYS,
           "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
           ", num of open handles: %u",
           __func__, handle, remote, hlist[domain].domainsCount);
-    }
   }
   FASTRPC_ATRACE_END();
   return nErr;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -129,6 +129,8 @@
 #define MAX_LIB_INSTANCE_ALLOWED 1
 #define ERRNO (errno ? errno : nErr ? nErr : -1)
 
+#define IS_CONST_HANDLE(h) (((h) < 0xff) ? 1 : 0)
+
 static void check_multilib_util(void);
 
 /* Array to store fastrpc library names. */

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1857,11 +1857,11 @@ bail:
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].open_handle_count);
-      } else
-          FARF(ALWAYS,
-             "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
-             ", num of open handles: %u",
-             __func__, handle, remote, hlist[domain].open_handle_count);
+    } else
+       FARF(ALWAYS,
+          "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
+          ", num of open handles: %u",
+          __func__, handle, remote, hlist[domain].open_handle_count);
   }
   FASTRPC_ATRACE_END();
   return nErr;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -129,8 +129,6 @@
 #define MAX_LIB_INSTANCE_ALLOWED 1
 #define ERRNO (errno ? errno : nErr ? nErr : -1)
 
-#define IS_CONST_HANDLE(h) (((h) < 0xff) ? 1 : 0)
-
 static void check_multilib_util(void);
 
 /* Array to store fastrpc library names. */
@@ -790,6 +788,8 @@ static const char *get_domain_from_id(int domain_id) {
   return uri_domain_suffix;
 }
 
+#define IS_CONST_HANDLE(h) (((h) < 0xff) ? 1 : 0)
+
 static int get_handle_remote(remote_handle64 local, remote_handle64 *remote) {
   struct handle_info *hinfo = (struct handle_info *)(uintptr_t)local;
   int nErr = AEE_SUCCESS;
@@ -858,7 +858,7 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
   case DOMAIN_LIST_PREPEND: {
     VERIFY(AEE_SUCCESS ==
            (nErr = fastrpc_alloc_handle(domain, &hlist[domain].ql, h, local)));
-    if (IS_CONST_HANDLE(h)) {
+    if(IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
       hlist[domain].constCount++;
       pthread_mutex_unlock(&hlist[domain].lmut);
@@ -872,7 +872,7 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
   case DOMAIN_LIST_DEQUEUE: {
     VERIFY(AEE_SUCCESS ==
            (nErr = fastrpc_free_handle(domain, &hlist[domain].ql, h)));
-    if (IS_CONST_HANDLE(h)) {
+    if(IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
       hlist[domain].constCount--;
       pthread_mutex_unlock(&hlist[domain].lmut);
@@ -1849,11 +1849,12 @@ bail:
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].open_handle_count);
-    } else
+    } else {
        FARF(ALWAYS,
           "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
           ", num of open handles: %u",
           __func__, handle, remote, hlist[domain].open_handle_count);
+    }
   }
   FASTRPC_ATRACE_END();
   return nErr;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1841,21 +1841,19 @@ bail:
         domain_deinit(domain);
       }
     if (nErr != AEE_SUCCESS) {
-      if (is_process_exiting(domain)) {
+      if (is_process_exiting(domain))
         return 0;
-      }
-      if (0 == check_rpc_error(nErr)) {
+      if (0 == check_rpc_error(nErr)) 
         FARF(ERROR,
            "Error 0x%x: %s failed for handle 0x%" PRIx64
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
-           hlist[domain].open_handle_count);
-      }
-    } else {
+           hlist[domain].domainsCount);
+      } else {
        FARF(ALWAYS,
           "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
           ", num of open handles: %u",
-          __func__, handle, remote, hlist[domain].open_handle_count);
+          __func__, handle, remote, hlist[domain].domainsCount);
     }
   }
   FASTRPC_ATRACE_END();

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -788,23 +788,6 @@ static const char *get_domain_from_id(int domain_id) {
   return uri_domain_suffix;
 }
 
-#define IS_CONST_HANDLE(h) (((h) < 0xff) ? 1 : 0)
-
-static bool is_last_handle(int domain) {
-  int nErr = AEE_SUCCESS, last = 0;
-
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
-  pthread_mutex_lock(&hlist[domain].lmut);
-  last = hlist[domain].domainsCount + hlist[domain].nondomainsCount;
-  pthread_mutex_unlock(&hlist[domain].lmut);
-bail:
-  if (nErr != AEE_SUCCESS) {
-    VERIFY_IPRINTF("Error 0x%x: %s failed for domain %d\n", nErr, __func__,
-                   domain);
-  }
-  return (last == 0);
-}
-
 static int get_handle_remote(remote_handle64 local, remote_handle64 *remote) {
   struct handle_info *hinfo = (struct handle_info *)(uintptr_t)local;
   int nErr = AEE_SUCCESS;
@@ -873,7 +856,11 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
   case DOMAIN_LIST_PREPEND: {
     VERIFY(AEE_SUCCESS ==
            (nErr = fastrpc_alloc_handle(domain, &hlist[domain].ql, h, local)));
-    if(IS_CONST_HANDLE(h)) {
+   if (!h) {
+      pthread_mutex_lock(&hlist[domain].lmut);
+      hlist[domain].rhzeroCount++;
+      pthread_mutex_unlock(&hlist[domain].lmut);
+    } else if (IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
       hlist[domain].constCount++;
       pthread_mutex_unlock(&hlist[domain].lmut);
@@ -887,7 +874,11 @@ int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 h,
   case DOMAIN_LIST_DEQUEUE: {
     VERIFY(AEE_SUCCESS ==
            (nErr = fastrpc_free_handle(domain, &hlist[domain].ql, h)));
-    if(IS_CONST_HANDLE(h)) {
+    if (!h) {
+      pthread_mutex_lock(&hlist[domain].lmut);
+      hlist[domain].rhzeroCount--;
+      pthread_mutex_unlock(&hlist[domain].lmut);
+    } else if (IS_CONST_HANDLE(h)) {
       pthread_mutex_lock(&hlist[domain].lmut);
       hlist[domain].constCount--;
       pthread_mutex_unlock(&hlist[domain].lmut);
@@ -1653,7 +1644,8 @@ bail:
     pdname_uri = NULL;
   }
   if (nErr == AEE_ECONNRESET) {
-    if (is_last_handle(domain)) {
+    if (!hlist[domain].domainsCount && !hlist[domain].rhzeroCount && !hlist[domain].nondomainsCount) {
+    /* Close session if there are no open remote handles */
       hlist[domain].disable_exit_logs = 1;
       domain_deinit(domain);
     }
@@ -1820,6 +1812,7 @@ bail:
 int remote_handle64_close(remote_handle64 handle) {
   remote_handle64 remote = 0;
   int domain = -1, nErr = AEE_SUCCESS, ref = 1;
+  bool start_deinit = false;
 
   FARF(RUNTIME_RPC_HIGH, "Entering %s, handle %llu\n", __func__, handle);
   FASTRPC_ATRACE_BEGIN_L("%s called with handle 0x%" PRIx64 "\n", __func__,
@@ -1828,34 +1821,41 @@ int remote_handle64_close(remote_handle64 handle) {
   VERIFY(AEE_SUCCESS == (nErr = get_domain_from_handle(handle, &domain)));
   VERIFY(AEE_SUCCESS == (nErr = get_handle_remote(handle, &remote)));
   set_thread_context(domain);
-  if (remote) {
+  /*
+   * Terminate remote session if
+   *     1. there are no open non-domain handles AND
+   *     2. there are no open multi-domain handles, OR
+   *        only 1 multi-domain handle is open (for perf reason,
+   *        skip closing of it)
+   */
+  if ((hlist[domain].domainsCount + hlist[domain].rhzeroCount) <= 1 && !hlist[domain].nondomainsCount)
+    start_deinit = true;
+  /*
+   * If session termination is not initiated and the remote handle is valid,
+   * then close the remote handle on DSP.
+   */
+  if (!start_deinit && remote) {
     VERIFY(AEE_SUCCESS ==
            (nErr = remote_handle_close_domain(domain, (remote_handle)remote)));
   }
-  fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, handle, NULL);
-  FASTRPC_PUT_REF(domain);
 bail:
   if (nErr != AEE_EINVHANDLE && is_domain_valid(domain)) {
-    if (is_valid_local_handle(domain, (struct handle_info *)handle)) {
-      if (is_last_handle(domain)) {
+     fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, handle, NULL);
+     FASTRPC_PUT_REF(domain);
+    if (start_deinit) {
         hlist[domain].disable_exit_logs = 1;
         domain_deinit(domain);
       }
-    } else {
-      nErr = AEE_ERPC;
-    }
-  } else if (nErr != AEE_SUCCESS) {
-    if (is_process_exiting(domain)) {
-      return 0;
-    }
-    if (0 == check_rpc_error(nErr)) {
-      FARF(ERROR,
+    if (nErr != AEE_SUCCESS) {
+      if (is_process_exiting(domain))
+        return 0;
+      if (0 == check_rpc_error(nErr))
+        FARF(ERROR,
            "Error 0x%x: %s failed for handle 0x%" PRIx64
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].open_handle_count);
-    }
-  } else {
+    } else {
     FARF(ALWAYS,
          "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
          ", num of open handles: %u",

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1857,11 +1857,11 @@ bail:
            " remote handle 0x%" PRIx64 " (errno %s), num of open handles: %u\n",
            nErr, __func__, handle, remote, strerror(errno),
            hlist[domain].open_handle_count);
-    } else {
-    FARF(ALWAYS,
-         "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
-         ", num of open handles: %u",
-         __func__, handle, remote, hlist[domain].open_handle_count);
+      } else
+          FARF(ALWAYS,
+             "%s: closed handle 0x%" PRIx64 " remote handle 0x%" PRIx64
+             ", num of open handles: %u",
+             __func__, handle, remote, hlist[domain].open_handle_count);
   }
   FASTRPC_ATRACE_END();
   return nErr;


### PR DESCRIPTION
Currently, after the last handle of a session is closed, the session is
also terminated. Instead, skip closing of the last handle and directly
terminate the remote session as this will reduce latency of session
cleanup.
Signed-off-by: Ramesh Nallagopu <quic_rnallago@quicinc.com>