### PR TITLE
Print Skel name during handle close

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -500,8 +500,12 @@ static __inline int convert_kernel_to_user_error(int nErr, int err_no) {
 	return nErr;
 }
 
+#ifdef __ANDROID__
 // Warning message to use domains
 #define PRINT_WARN_USE_DOMAINS() VERIFY_WPRINTF("Warning: %s: Non-domain usage of FastRPC will be deprecated, use domains to offload to DSP using FastRPC", __func__)
+#else
+#define PRINT_WARN_USE_DOMAINS() 0
+#endif
 
 /**
   * @brief utility APIs used in fastRPC library to get name, handle from domain 

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -118,6 +118,11 @@ static __inline uint32 Q6_R_cl0_R(uint32 num) {
 #define FASTRPC_MAX_DSP_ATTRIBUTES_FALLBACK  1
 #endif
 
+#define container_of(ptr, type, member) ({                      \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+
+
 /**
   * @brief DSP thread specific information are stored here
   * priority, stack size are client configurable.
@@ -532,7 +537,7 @@ remote_handle64 get_adsp_perf1_handle(int domain);
   * @returns: 0 on success, valid non-zero error code on failure
   *
   **/
-int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local);
+int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local, const char *name);
 
 /**
   * @brief functions to wrap ioctl syscalls for downstream and upstream kernel

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -836,9 +836,9 @@ static void print_open_handles(int domain) {
 	pthread_mutex_lock(&hlist[domain].mut);
 	QLIST_FOR_ALL(&hlist[domain].ql, pn) {
 		hi = STD_RECOVER_REC(struct handle_info, qn, pn);
-		if (hi->lib_name)
+		if (hi->name)
 			FARF(ALWAYS, "%s, handle 0x%"PRIx64"",
-				hi->lib_name, hi->remote);
+				hi->name, hi->remote);
 	}
 	pthread_mutex_unlock(&hlist[domain].mut);
 }
@@ -1821,7 +1821,7 @@ int remote_handle_close_domain(int domain, remote_handle h) {
   int dlerr = 0, nErr = AEE_SUCCESS;
   size_t err_str_len = MAX_DLERRSTR_LEN * sizeof(char);
   uint64_t t_close = 0;
-  struct *hi = container_of((void*)(uint64_t)h, struct handle_info, local);
+  struct handle_info *hi = container_of((void*)(uint64_t)h, struct handle_info, local);
   char *name = hi->name, *nullname = "(null)";
   remote_handle64 handle = INVALID_HANDLE;
 

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -353,7 +353,7 @@ int fastrpc_session_open(int domain, int *dev) {
     *dev = device;
     return 0;
   }
-  return AEE_EUNKNOWN;
+  return AEE_ECONNREFUSED;
 }
 
 int fastrpc_session_close(int domain, int dev) {
@@ -3214,7 +3214,9 @@ static int open_device_node(int domain_id) {
   if (dev < 0)
     FARF(ERROR,
          "Error 0x%x: %s failed for domain ID %d, sess ID %d secure dev : %s, "
-         "dev : %s. (errno %d, %s)",
+         "dev : %s. (errno %d, %s) (Either the remote processor is down, or "
+         "application does not have permission to access the remote "
+         "processor\n",
          nErr, __func__, domain_id, sess_id, get_secure_domain_name(domain),
          get_domain_name(domain), errno, strerror(errno));
   return dev;
@@ -3523,7 +3525,7 @@ static int remote_init(int domain) {
   VERIFYC(pd_type > DEFAULT_UNUSED && pd_type < MAX_PD_TYPE, AEE_EBADITEM);
   if (hlist[domain].dev == -1) {
     dev = open_device_node(domain);
-    VERIFYM(dev >= 0, AEE_ERPC, "open dev failed\n");
+    VERIFYC(dev >= 0, AEE_ECONNREFUSED);
     // Set session relation info using FASTRPC_INVOKE2_SESS_INFO
     sess_info.domain_id = info;
     sess_info.pd_type = pd_type;

--- a/src/fastrpc_perf.c
+++ b/src/fastrpc_perf.c
@@ -249,7 +249,7 @@ static int perf_dsp_enable(int domain) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: adsp_perf1 domains not supported for domain %d\n",
            nErr, __func__, domain);
-      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, gperf.adsp_perf_handle, NULL);
+      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, gperf.adsp_perf_handle, NULL, NULL);
       gperf.adsp_perf_handle = INVALID_HANDLE;
       VERIFY(0 == (nErr = adsp_perf_get_keys(keys, PERF_KEY_STR_MAX, &maxLen,
                                              &numKeys)));

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -156,8 +156,14 @@ static void listener(struct listener *me) {
     }
     if (nErr) {
       if (nErr == AEE_EINTERRUPTED) {
-        goto invoke;
+          /* UserPD in CPZ migration. Keep retrying until 
+          migration is complete */
+          goto invoke;
+      } else if (nErr == (DSP_AEE_EOFFSET + AEE_EBADSTATE)) {
+          /* UserPD in irrecoverable bad state. Exit listener */
+          goto bail;
       }
+      /* For any other error, retry once and exit if error seen again */
       if (me->adsp_listener1_handle != INVALID_HANDLE) {
         nErr = __QAIC_HEADER(adsp_listener1_next2)(
             me->adsp_listener1_handle, ctx, nErr, 0, 0, &ctx, &handle, &sc,

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -58,7 +58,7 @@ __QAIC_IMPL(apps_remotectl_open)(const char *name, uint32 *handle, char *dlStr,
          (nErr = mod_table_open(name, handle, dlStr, dlerrorLen, dlErr)));
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local)));
+              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local, NULL)));
 bail:
   return nErr;
 }
@@ -80,7 +80,7 @@ __QAIC_IMPL(apps_remotectl_close)(uint32 handle, char *errStr, int errStrLen,
   }
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL)));
+              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL, NULL)));
 bail:
   return nErr;
 }
@@ -344,7 +344,7 @@ static void *listener_start_thread(void *arg) {
   if (nErr) {
     FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
          nErr, __func__);
-    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, adsp_listener1_handle, NULL);
+    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, adsp_listener1_handle, NULL, NULL);
     VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
   } else {
     me->adsp_listener1_handle = adsp_listener1_handle;


### PR DESCRIPTION
Print skel name during handle close

Other minor changes
 - Optimize listener deinit by reducing remote calls
 - Disable warning logs for LE
