### PR TITLE
Migrate all rpcmem_alloc to rpcmem_alloc_internal 

### DIFF
--- a/inc/fastrpc_apps_user.h
+++ b/inc/fastrpc_apps_user.h
@@ -21,13 +21,6 @@
 #endif
 
 /*
- * API to check if kernel supports remote memory allocation
- * Returns 0 if NOT supported
- *
- */
-int is_kernel_alloc_supported(int dev, int domain);
-
-/*
  * API to initialize rpcmem data structures for ION allocation
  */
 int rpcmem_init_internal();

--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -93,6 +93,22 @@
 									  ref = 0;	\
                                     }
 
+/**
+  * @brief Process types on remote subsystem
+  * Always add new PD types at the end, before MAX_PD_TYPE,
+  * for maintaining back ward compatibility
+ **/
+#define DEFAULT_UNUSED    0  /* pd type not configured for context banks */
+#define ROOT_PD           1  /* Root PD */
+#define AUDIO_STATICPD    2  /* ADSP Audio Static PD */
+#define SENSORS_STATICPD  3  /* ADSP Sensors Static PD */
+#define SECURE_STATICPD   4  /* CDSP Secure Static PD */
+#define OIS_STATICPD      5  /* ADSP OIS Static PD */
+#define CPZ_USERPD        6  /* CDSP CPZ USER PD */
+#define USERPD            7  /* DSP User Dynamic PD */
+#define GUEST_OS_SHARED   8  /* Legacy Guest OS Shared */
+#define MAX_PD_TYPE       9  /* Max PD type */
+
 /*
  * Enum defined for fastrpc User Properties
  * @fastrpc_properties: Object of enum
@@ -130,6 +146,11 @@ enum fastrpc_internal_attributes {
    FASTRPC_MAX_ATTRIBUTES  = DSPSIGNAL_DRIVER_SUPPORT + 1, /**<  Max DSP/Kernel attributes supported */
 };
 
+/* Utility function to get pd type of a DSP domain
+ * @domain: DSP domain ID
+ * @return -1 if device not opened and pd type if opened
+ */
+int fastrpc_get_pd_type(int domain);
 /**
   * @brief API to initialize the global data strcutures in fastRPC library
   */

--- a/inc/fastrpc_config.h
+++ b/inc/fastrpc_config.h
@@ -210,4 +210,11 @@ int fastrpc_config_get_caller_stack_num(void);
   **/
 int fastrpc_config_init();
 
+/*
+ * fastrpc_config_is_setdmabufname_enabled() - Check if DMA allocated buffer
+ * name attribute debug support has been requested.
+ * Returns: True or False, status of debug support
+ */
+boolean fastrpc_config_is_setdmabufname_enabled(void);
+
 #endif /*__FASTRPC_CONFIG_H__*/

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -308,7 +308,6 @@ struct fastrpc_map {
   *    dsppd - Type of the process that should be created on DSP (specific domain)
   *    dsppdname - Name of the process
   *    sessionname - Name of the session, if more than one process created on same DSP
-  *    domainsupport - Legacy field, should be 1 always.
   *    kmem_support - Stores whether kernel can allocate memory for signed process
   *    dev - file descriptor returned by open(<fastrpc_device_node>)
   *    cphandle, msghandle, lsitenerhandle, remotectlhandle, adspperfhandle - static
@@ -334,7 +333,6 @@ struct handle_list {
 	int dsppd;
 	char dsppdname[MAX_DSPPD_NAMELEN];
 	char sessionname[MAX_DSPPD_NAMELEN];
-	int domainsupport;
 	int kmem_support;
 	int dev;
 	int setmode;

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -500,8 +500,12 @@ static __inline int convert_kernel_to_user_error(int nErr, int err_no) {
 	return nErr;
 }
 
+#ifdef __ANDROID__
 // Warning message to use domains
 #define PRINT_WARN_USE_DOMAINS() VERIFY_WPRINTF("Warning: %s: Non-domain usage of FastRPC will be deprecated, use domains to offload to DSP using FastRPC", __func__)
+#else
+#define PRINT_WARN_USE_DOMAINS() 0
+#endif
 
 /**
   * @brief utility APIs used in fastRPC library to get name, handle from domain 

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -118,6 +118,11 @@ static __inline uint32 Q6_R_cl0_R(uint32 num) {
 #define FASTRPC_MAX_DSP_ATTRIBUTES_FALLBACK  1
 #endif
 
+#define container_of(ptr, type, member) ({                      \
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+
+
 /**
   * @brief DSP thread specific information are stored here
   * priority, stack size are client configurable.
@@ -532,7 +537,7 @@ remote_handle64 get_adsp_perf1_handle(int domain);
   * @returns: 0 on success, valid non-zero error code on failure
   *
   **/
-int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local);
+int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local, const char *name);
 
 /**
   * @brief functions to wrap ioctl syscalls for downstream and upstream kernel

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -96,23 +96,6 @@ static __inline uint32 Q6_R_cl0_R(uint32 num) {
 #define FASTRPC_INIT_CREATE_STATIC  2
 #define FASTRPC_INIT_ATTACH_SENSORS 3
 
-/**
-  * @brief Process types on remote subsystem
-  * Always add new PD types at the end, before MAX_PD_TYPE,
-  * for maintaining back ward compatibility
- **/
-#define DEFAULT_UNUSED    0  /* pd type not configured for context banks */
-#define ROOT_PD           1  /* Root PD */
-#define AUDIO_STATICPD    2  /* ADSP Audio Static PD */
-#define SENSORS_STATICPD  3  /* ADSP Sensors Static PD */
-#define SECURE_STATICPD   4  /* CDSP Secure Static PD */
-#define OIS_STATICPD      5  /* ADSP OIS Static PD */
-#define CPZ_USERPD        6  /* CDSP CPZ USER PD */
-#define USERPD            7  /* DSP User Dynamic PD */
-#define GUEST_OS_SHARED   8  /* Legacy Guest OS Shared */
-#define MAX_PD_TYPE       9  /* Max PD type */
-
-
 // Attribute to specify the process is a debug process
 #define FASTRPC_ATTR_DEBUG_PROCESS (1)
 

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -77,6 +77,12 @@ static __inline uint32 Q6_R_cl0_R(uint32 num) {
 /* From actual domain ID (0-3) and session ID, get effective domain ID */
 #define GET_EFFECTIVE_DOMAIN_ID(domain, session) (domain + (NUM_DOMAINS * session))
 
+/* Check if given effective domain ID is in valid range */
+#define IS_VALID_EFFECTIVE_DOMAIN_ID(domain) ((domain >= 0) && (domain < NUM_DOMAINS_EXTEND))
+
+/* Check if given effective domain ID is in extended range */
+#define IS_EXTENDED_DOMAIN_ID(domain) ((domain >= NUM_DOMAINS) && (domain < NUM_DOMAINS_EXTEND))
+
 /**
  * @brief  PD initialization types used to create different kinds of PD
  * Attach is used for attaching the curent APPS process to the existing

--- a/inc/fastrpc_trace.h
+++ b/inc/fastrpc_trace.h
@@ -30,29 +30,28 @@
 		FARF(RUNTIME_RPC_HIGH,fmt,##__VA_ARGS__);\
 		snprintf(systrace_string, SYSTRACE_STR_LEN, fmt, ##__VA_ARGS__);\
 		ATRACE_BEGIN(systrace_string); \
-	} \
-	else \
+	} else \
 		(void)0
 #define FASTRPC_ATRACE_END_L(fmt, ...)\
 	if(is_systrace_enabled()){ \
 		FARF(ALWAYS, fmt, ##__VA_ARGS__);\
 		ATRACE_END(); \
-	} \
-	else \
-		(void)0
+	} else { \
+		FARF(RUNTIME_RPC_CRITICAL,fmt,##__VA_ARGS__);\
+	}
 #define FASTRPC_ATRACE_BEGIN()\
 	if(is_systrace_enabled()){ \
 		FARF(ALWAYS, "%s begin", __func__);\
 		ATRACE_BEGIN(__func__); \
-	} \
-	else \
+	} else \
 		(void)0
 #define FASTRPC_ATRACE_END()\
 	if(is_systrace_enabled()) { \
 		FARF(ALWAYS, "%s end", __func__);\
 		ATRACE_END(); \
-	} else \
-		(void)0
+	}  else { \
+		FARF(RUNTIME_RPC_CRITICAL,"%s end", __func__);\
+	}
 #endif
 
 //API to get Systrace variable

--- a/inc/rpcmem_internal.h
+++ b/inc/rpcmem_internal.h
@@ -7,6 +7,22 @@
 #include "rpcmem.h"
 
 /*
+ * rpcmem_set_dmabuf_name() - API to set name for DMA allocated buffer.
+ *                            Name string updates as follows.
+ *                            Heap : dsp_<pid>_<tid>_<remote-flags>
+ *                            Non-heap : apps_<pid>_<tid>_<rpcflags>
+ *
+ * @name    : Pointer to string, "dsp" for heap buffers, "apps" for
+ *            non-heap buffers
+ * @fd      : File descriptor of buffer
+ * @heapid  : Heap ID used for memory allocation
+ * @buf     : Pointer to buffer start address
+ * @rpcflags: Memory flags describing attributes of allocation
+ * Return   : 0 on success, valid non-zero error code on failure
+ */
+int rpcmem_set_dmabuf_name(const char *name, int fd, int heapid,
+				void *buf, uint32 rpc_flags);
+/*
  * returns an file descriptor associated with the address
  */
 int rpcmem_to_fd_internal(void *po);

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -22,12 +22,21 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/eventfd.h>
+#include <sys/inotify.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #define MAX_DOMAIN_URI_SIZE 12
 #define ROOTPD_NAME "rootpd"
 #define ATTACH_GUESTOS "attachguestos"
 #define CREATE_STATICPD "createstaticpd:"
+#define POLL_TIMEOUT	10 * 1000
+#define EVENT_SIZE		( sizeof (struct inotify_event) )
+#define EVENT_BUF_LEN	( 1024 * ( EVENT_SIZE + 16 ) )
+#define ADSP_SECURE_DEVICE_NAME "fastrpc-adsp-secure"
+#define SDSP_SECURE_DEVICE_NAME "fastrpc-sdsp-secure"
+#define MDSP_SECURE_DEVICE_NAME "fastrpc-mdsp-secure"
+#define CDSP_SECURE_DEVICE_NAME "fastrpc-cdsp-secure"
 
 // Array of supported domain names and its corresponding ID's.
 static domain_t supported_domains[] = {{ADSP_DOMAIN_ID, ADSP_DOMAIN},
@@ -46,6 +55,125 @@ static domain_t *get_domain_uri(int domain_id) {
   }
 
   return NULL;
+}
+
+static const char *get_secure_device_name(int domain_id) {
+	const char *name;
+	int domain = domain_id & DOMAIN_ID_MASK;
+
+	switch (domain) {
+	case ADSP_DOMAIN_ID:
+		name = ADSP_SECURE_DEVICE_NAME;
+		break;
+	case SDSP_DOMAIN_ID:
+		name = SDSP_SECURE_DEVICE_NAME;
+		break;
+	case MDSP_DOMAIN_ID:
+		name = MDSP_SECURE_DEVICE_NAME;
+		break;
+	case CDSP_DOMAIN_ID:
+		name = CDSP_SECURE_DEVICE_NAME;
+		break;
+	default:
+		name = DEFAULT_DEVICE;
+		break;
+	}
+
+	return name;
+}
+
+/**
+ * fastrpc_dev_exists() - Check if device exists
+ * @dev_name: Device name
+ *
+ * Return:
+ *	True: Device node exists
+ *	False: Device node does not exist
+ */
+static boolean fastrpc_dev_exists(const char* dev_name)
+{
+	struct stat buffer;
+	char *path = NULL;
+	uint64 len;
+
+	len = snprintf(0, 0, "/dev/%s", dev_name) + 1;
+	if(NULL == (path = (char *)malloc(len * sizeof(char))))
+		return false;
+
+	snprintf(path, (int)len, "/dev/%s", dev_name);
+
+	return (stat(path, &buffer) == 0);
+}
+
+/**
+ * fastrpc_wait_for_secure_device() - Wait for secure device node
+ * @domain: Domain ID
+ *
+ * Return:
+ *	0 - Success
+ *	Non-zero - Failure
+ */
+static int fastrpc_wait_for_secure_device(int domain)
+{
+	int inotify_fd = -1, watch_fd = -1, err = 0;
+	const char *dev_name = NULL;
+	struct pollfd pfd[1];
+
+	dev_name = get_secure_device_name(domain);
+
+	if (fastrpc_dev_exists(dev_name))
+		return 0;
+
+	inotify_fd = inotify_init();
+	if (inotify_fd < 0) {
+		VERIFY_EPRINTF("Error: inotify_init failed, invalid fd errno = %s\n", strerror(errno));
+		return AEE_EINVALIDFD;
+	}
+
+	watch_fd = inotify_add_watch(inotify_fd, "/dev/", IN_CREATE);
+	if (watch_fd < 0) {
+		close(inotify_fd);
+		VERIFY_EPRINTF("Error: inotify_add_watch failed, invalid fd errno = %s\n", strerror(errno));
+		return AEE_EINVALIDFD;
+	}
+	memset(pfd, 0 , sizeof(pfd));
+	pfd[0].fd = inotify_fd;
+	pfd[0].events = POLLIN;
+
+	while (1) {
+		int ret = 0;
+		char buffer[EVENT_BUF_LEN];
+
+		ret = poll(pfd, 1, POLL_TIMEOUT);
+		if(ret < 0){
+			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));
+			err = AEE_EPOLL;
+			break;
+		}
+		if(ret == 0){
+			VERIFY_EPRINTF("Error: %s: Poll timeout\n", __func__);
+			err = AEE_EPOLL;
+			break;
+		}
+		ssize_t len = read(inotify_fd, buffer, sizeof(buffer));
+		if (len < 0) {
+			VERIFY_EPRINTF("Error: %s: read failed, errno = %s\n", __func__, strerror(errno));
+			err = AEE_EEVENTREAD;
+			break;
+		}
+		// Check if the event corresponds to the creation of the device node.
+		struct inotify_event* event = (struct inotify_event*)buffer;
+		if (event->wd == watch_fd && (event->mask & IN_CREATE) &&
+			(std_strcmp(dev_name, event->name) == 0)) {
+			// Device node created, process proceed to open and use it.
+			VERIFY_IPRINTF("Device node created!\n");
+			break; // Exit the loop after device creation is detected.
+		}
+	}
+	inotify_rm_watch(inotify_fd, watch_fd);
+	close(inotify_fd);
+
+	return err;
 }
 
 int adsp_default_listener_start(int argc, char *argv[]) {
@@ -79,6 +207,7 @@ int adsp_default_listener_start(int argc, char *argv[]) {
     VERIFYC(NULL != (dsp_domain = get_domain_uri(domain_id)),
             AEE_EINVALIDDOMAIN);
 
+    VERIFYC(AEE_SUCCESS == (nErr = fastrpc_wait_for_secure_device(domain_id)), AEE_ECONNREFUSED);
     // Allocate memory for URI. Example: "ITRANSPORT_PREFIX
     // createstaticpd:audiopd&dom=adsp"
     namelen = strlen(ITRANSPORT_PREFIX CREATE_STATICPD) + strlen(argv[1]) +
@@ -114,6 +243,7 @@ int adsp_default_listener_start(int argc, char *argv[]) {
 
     // If domain name part of arguments, use domains API
     if (domain_id != INVALID_DOMAIN_ID) {
+      VERIFYC(AEE_SUCCESS == (nErr = fastrpc_wait_for_secure_device(domain_id)), AEE_ECONNREFUSED);
       VERIFY(AEE_SUCCESS == (nErr = remote_handle64_open(argv[1], &fd)));
       goto start_listener;
     }
@@ -137,6 +267,7 @@ int adsp_default_listener_start(int argc, char *argv[]) {
                 strlen(ITRANSPORT_PREFIX ATTACH_GUESTOS) + 1);
   }
 
+  VERIFYC(AEE_SUCCESS == (nErr = fastrpc_wait_for_secure_device(DEFAULT_DOMAIN_ID)), AEE_ECONNREFUSED);
   // Default case: Open non-domain static process handle
   VERIFY_IPRINTF("%s started with arguments %s\n", __func__, name);
   VERIFY(AEE_SUCCESS == (nErr = remote_handle_open(name, (remote_handle *)&fd)));

--- a/src/apps_mem_imp.c
+++ b/src/apps_mem_imp.c
@@ -112,7 +112,7 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32 lflags, uint32 rflags,
     VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
             AEE_ENORPCMEMORY);
     VERIFYC(0 < (fd = rpcmem_to_fd_internal(buf)), AEE_EBADFD);
-
+    rpcmem_set_dmabuf_name("dsp", fd, heapid, buf, lflags);
     /* Using FASTRPC_MAP_FD_DELAYED as only HLOS mapping is reqd at this point
      */
     VERIFY(AEE_SUCCESS == (nErr = fastrpc_mmap(domain, fd, buf, 0, len,
@@ -140,6 +140,7 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32 lflags, uint32 rflags,
               AEE_ENORPCMEMORY);
       fd = rpcmem_to_fd_internal(buf);
       VERIFYC(fd > 0, AEE_EBADPARM);
+      rpcmem_set_dmabuf_name("dsp", fd, heapid, buf, lflags);
     }
     VERIFY(AEE_SUCCESS ==
            (nErr = remote_mmap64_internal(fd, rflags, (uint64_t)buf, len,

--- a/src/dspqueue/dspqueue_cpu.c
+++ b/src/dspqueue/dspqueue_cpu.c
@@ -33,7 +33,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
-#include <rpcmem.h>
+#include <rpcmem_internal.h>
 #include <stdatomic.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -263,7 +263,7 @@ static AEEResult init_domain_queues_locked(int domain) {
   }
 
   // Allocate shared state structure and pass to DSP
-  VERIFYC((dq->state = rpcmem_alloc(
+  VERIFYC((dq->state = rpcmem_alloc_internal(
                RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG,
                sizeof(struct dspqueue_process_queue_state))) != NULL,
           AEE_ENORPCMEMORY);
@@ -536,7 +536,7 @@ AEEResult dspqueue_create(int domain, uint32_t flags, uint32_t req_queue_size,
       CACHE_ALIGN_SIZE(req_queue_size) + CACHE_ALIGN_SIZE(resp_queue_size);
 
   // Allocate queue shared memory and map to DSP
-  VERIFYC((q->user_queue = rpcmem_alloc(
+  VERIFYC((q->user_queue = rpcmem_alloc_internal(
                RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_HEAP_NOREG,
                q->user_queue_size)) != NULL,
           AEE_ENOMEMORY);

--- a/src/dspqueue/dspqueue_cpu.c
+++ b/src/dspqueue/dspqueue_cpu.c
@@ -183,7 +183,7 @@ static AEEResult init_domain_queues_locked(int domain) {
   uint32_t cap = 0;
 
   errno = 0;
-  assert(domain < NUM_DOMAINS_EXTEND);
+  assert(IS_VALID_EFFECTIVE_DOMAIN_ID(domain));
   if (queues->domain_queues[domain] != NULL) {
     return AEE_SUCCESS;
   }
@@ -365,7 +365,7 @@ static AEEResult destroy_domain_queues_locked(int domain) {
 
   errno = 0;
   FARF(HIGH, "destroy_domain_queues_locked");
-  assert(domain < NUM_DOMAINS_EXTEND);
+  assert(IS_VALID_EFFECTIVE_DOMAIN_ID(domain));
   assert(queues->domain_queues[domain] != NULL);
   dq = queues->domain_queues[domain];
   assert(dq->num_queues == 0);
@@ -449,10 +449,10 @@ AEEResult dspqueue_create(int domain, uint32_t flags, uint32_t req_queue_size,
   if (domain == -1) {
     PRINT_WARN_USE_DOMAINS();
     domain = get_current_domain();
-    if ((domain < 0) || (domain >= NUM_DOMAINS_EXTEND)) {
+    if (!IS_VALID_EFFECTIVE_DOMAIN_ID(domain)) {
       return AEE_ERPC;
     }
-  } else if ((domain < 0) || (domain >= NUM_DOMAINS_EXTEND)) {
+  } else if (!IS_VALID_EFFECTIVE_DOMAIN_ID(domain)) {
     return AEE_EBADPARM;
   }
 
@@ -742,7 +742,7 @@ AEEResult dspqueue_close(dspqueue_t queue) {
 
   errno = 0;
   VERIFYC(q, AEE_EBADPARM);
-  VERIFYC(q->domain >= 0 && q->domain < NUM_DOMAINS_EXTEND, AEE_EINVALIDDOMAIN);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(q->domain), AEE_EINVALIDDOMAIN);
   pthread_mutex_lock(&queues->mutex);
   dq = queues->domain_queues[q->domain];
   if (dq == NULL) {
@@ -2285,7 +2285,7 @@ static int dspqueue_notif_callback(void *context, int domain, int session,
   }
   FARF(ALWAYS, "%s for domain %d, session %d, status %u", __func__, domain,
        session, status);
-  assert(effec_domain_id < NUM_DOMAINS_EXTEND);
+  assert(IS_VALID_EFFECTIVE_DOMAIN_ID(effec_domain_id));
 
   // Send different error codes for SSR and remote-process exit
   nErr = (status == FASTRPC_DSP_SSR) ? AEE_ECONNRESET : AEE_ENOSUCH;

--- a/src/dspsignal.c
+++ b/src/dspsignal.c
@@ -67,7 +67,7 @@ static AEEResult init_domain_signals(int domain) {
   AEEResult nErr = AEE_SUCCESS;
   struct dspsignal_domain_signals *ds = NULL;
 
-  VERIFY((domain < NUM_DOMAINS_EXTEND) && (domain >= 0));
+  VERIFY(IS_VALID_EFFECTIVE_DOMAIN_ID(domain));
 
   // Initialize process-level structure
   if ((pthread_once(&signals_once, init_process_signals_once) != 0) ||
@@ -111,7 +111,7 @@ void dspsignal_domain_deinit(int domain) {
 
   if (!signals)
     return;
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   pthread_mutex_lock(&signals->mutex);
   if (signals->domain_signals[domain]) {
     free(signals->domain_signals[domain]);
@@ -136,7 +136,7 @@ AEEResult dspsignal_create(int domain, uint32_t id, uint32_t flags) {
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
   VERIFYC(flags == 0, AEE_EBADPARM);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFY((nErr = init_domain_signals(domain)) == 0);
   VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
   e = ioctl_signal_create(ds->dev, id, flags);
@@ -172,7 +172,7 @@ AEEResult dspsignal_destroy(int domain, uint32_t id) {
 
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
   e = ioctl_signal_destroy(ds->dev, id);
   if (e != 0) {
@@ -203,7 +203,7 @@ AEEResult dspsignal_signal(int domain, uint32_t id) {
 
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
 
   FARF(MEDIUM, "%s: Send signal %u", __func__, id);
@@ -235,7 +235,7 @@ AEEResult dspsignal_wait(int domain, uint32_t id, uint32_t timeout_usec) {
 
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
   fastrpc_qos_activity(domain);
 
@@ -275,7 +275,7 @@ AEEResult dspsignal_cancel_wait(int domain, uint32_t id) {
 
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
 
   FARF(MEDIUM, "%s: Cancel wait signal %u", __func__, id);

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3017,6 +3017,14 @@ bail:
   return domain;
 }
 
+int fastrpc_get_pd_type(int domain) {
+	if (hlist && (hlist[domain].dev != -1)) {
+		return hlist[domain].dsppd;
+	} else {
+		return -1;
+	}
+}
+
 int get_current_domain(void) {
   struct handle_list *list;
   int domain = -1;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -836,9 +836,9 @@ static void print_open_handles(int domain) {
 	pthread_mutex_lock(&hlist[domain].mut);
 	QLIST_FOR_ALL(&hlist[domain].ql, pn) {
 		hi = STD_RECOVER_REC(struct handle_info, qn, pn);
-		if (hi->lib_name)
+		if (hi->name)
 			FARF(ALWAYS, "%s, handle 0x%"PRIx64"",
-				hi->lib_name, hi->remote);
+				hi->name, hi->remote);
 	}
 	pthread_mutex_unlock(&hlist[domain].mut);
 }
@@ -1821,7 +1821,7 @@ int remote_handle_close_domain(int domain, remote_handle h) {
   int dlerr = 0, nErr = AEE_SUCCESS;
   size_t err_str_len = MAX_DLERRSTR_LEN * sizeof(char);
   uint64_t t_close = 0;
-  struct *hi = container_of((void*)(uint64_t)h, struct handle_info, local);
+  struct handle_info *hi = container_of((void*)(uint64_t)h, struct handle_info, local);
   char *name = hi->name, *nullname = "(null)";
   remote_handle64 handle = INVALID_HANDLE;
 

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -353,7 +353,7 @@ int fastrpc_session_open(int domain, int *dev) {
     *dev = device;
     return 0;
   }
-  return AEE_EUNKNOWN;
+  return AEE_ECONNREFUSED;
 }
 
 int fastrpc_session_close(int domain, int dev) {
@@ -3214,7 +3214,9 @@ static int open_device_node(int domain_id) {
   if (dev < 0)
     FARF(ERROR,
          "Error 0x%x: %s failed for domain ID %d, sess ID %d secure dev : %s, "
-         "dev : %s. (errno %d, %s)",
+         "dev : %s. (errno %d, %s) (Either the remote processor is down, or "
+         "application does not have permission to access the remote "
+         "processor\n",
          nErr, __func__, domain_id, sess_id, get_secure_domain_name(domain),
          get_domain_name(domain), errno, strerror(errno));
   return dev;
@@ -3523,7 +3525,7 @@ static int remote_init(int domain) {
   VERIFYC(pd_type > DEFAULT_UNUSED && pd_type < MAX_PD_TYPE, AEE_EBADITEM);
   if (hlist[domain].dev == -1) {
     dev = open_device_node(domain);
-    VERIFYM(dev >= 0, AEE_ERPC, "open dev failed\n");
+    VERIFYC(dev >= 0, AEE_ECONNREFUSED);
     // Set session relation info using FASTRPC_INVOKE2_SESS_INFO
     sess_info.domain_id = info;
     sess_info.pd_type = pd_type;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3686,9 +3686,9 @@ static int remote_init(int domain) {
                   std_strlen(hlist[domain].dsppdname) + 1);
       filelen = std_strlen(hlist[domain].dsppdname) + 1;
       flags = FASTRPC_INIT_CREATE_STATIC;
-      // 2MB of remote heap for dynamic loading is available only for Audio PD.
+      // 3MB of remote heap for dynamic loading is available only for Audio PD.
       if (pd_type == AUDIO_STATICPD) {
-        memlen = 2 * 1024 * 1024;
+        memlen = 3 * 1024 * 1024;
       }
       ioErr =
           ioctl_init(dev, flags, 0, (byte *)file, filelen, -1, 0, memlen, 0, 0);

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -4080,24 +4080,21 @@ static void exit_thread(void *value) {
   list = (struct handle_list *)value;
   if (list) {
     domain = (int)(list - &hlist[0]);
-    FARF(RUNTIME_RPC_CRITICAL, "%s: dom:%d, dev:%d", __func__, domain,
-         list->dev);
   }
 
   for (domain = 0; domain < NUM_DOMAINS_EXTEND; domain++) {
     if (hlist[domain].dev != -1) {
-      FARF(RUNTIME_RPC_CRITICAL, "%s: dom:%d", __func__, domain);
       if ((handle = get_adsp_current_process1_handle(domain)) !=
           INVALID_HANDLE) {
         nErr = adsp_current_process1_thread_exit(handle);
         if (nErr) {
-          FARF(CRITICAL, "%s: nErr:0x%x, dom:%d, h:0x%llx", __func__, nErr,
+          FARF(RUNTIME_RPC_HIGH, "%s: nErr:0x%x, dom:%d, h:0x%llx", __func__, nErr,
                domain, handle);
         }
       } else if (domain == DEFAULT_DOMAIN_ID) {
         nErr = adsp_current_process_thread_exit();
         if (nErr) {
-          FARF(CRITICAL, "%s: nErr:0x%x, dom:%d", __func__, nErr, domain);
+          FARF(RUNTIME_RPC_HIGH, "%s: nErr:0x%x, dom:%d", __func__, nErr, domain);
         }
       }
     }

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1455,6 +1455,7 @@ bail:
 
 int remote_handle_invoke(remote_handle handle, uint32_t sc, remote_arg *pra) {
   int domain = -1, nErr = AEE_SUCCESS, ref = 0;
+  struct handle_info *h = container_of((void*)(uint64_t)handle, struct handle_info, local);
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
@@ -1478,9 +1479,9 @@ bail:
     if (0 == check_rpc_error(nErr)) {
       if (get_logger_state(domain)) {
         FARF(ERROR,
-             "Error 0x%x: %s failed for handle 0x%x, method %d on domain %d "
+             "Error 0x%x: %s failed for module %s handle 0x%x, method %d on domain %d "
              "(sc 0x%x) (errno %s)\n",
-             nErr, __func__, (int)handle, REMOTE_SCALARS_METHOD(sc), domain, sc,
+             nErr, __func__, h->name, (int)handle, REMOTE_SCALARS_METHOD(sc), domain, sc,
              strerror(errno));
       }
     }
@@ -1493,6 +1494,7 @@ int remote_handle64_invoke(remote_handle64 local, uint32_t sc,
                            remote_arg *pra) {
   remote_handle64 remote = 0;
   int nErr = AEE_SUCCESS, domain = -1, ref = 0;
+  struct handle_info *h = container_of((void*)(uint64_t)local, struct handle_info, local);
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
@@ -1514,9 +1516,9 @@ bail:
     if (0 == check_rpc_error(nErr)) {
       if (get_logger_state(domain)) {
         FARF(ERROR,
-             "Error 0x%x: %s failed for handle 0x%" PRIx64
+             "Error 0x%x: %s failed for module %s, handle 0x%" PRIx64
              ", method %d on domain %d (sc 0x%x) (errno %s)\n",
-             nErr, __func__, local, REMOTE_SCALARS_METHOD(sc), domain, sc,
+             nErr, __func__, h->name, local, REMOTE_SCALARS_METHOD(sc), domain, sc,
              strerror(errno));
       }
     }

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1783,7 +1783,6 @@ int remote_handle64_open(const char *name, remote_handle64 *ph) {
   domain = get_domain_from_name(name, DOMAIN_NAME_IN_URI);
   VERIFYC(domain >= 0, AEE_EBADPARM);
   FASTRPC_GET_REF(domain);
-  hlist[domain].domainsupport = 1;
   VERIFY(AEE_SUCCESS == (nErr = remote_handle_open_domain(domain, name, &h,
                                                           &t_spawn, &t_load)));
   /* Returning local handle to "geteventd" call causes bad fd error when daemon
@@ -3136,7 +3135,6 @@ static void domain_deinit(int domain) {
     hlist[domain].cphandle = 0;
     hlist[domain].msghandle = 0;
     hlist[domain].remotectlhandle = 0;
-    hlist[domain].domainsupport = 0;
     hlist[domain].listenerhandle = 0;
     hlist[domain].dev = -1;
     hlist[domain].info = -1;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1227,7 +1227,7 @@ int remote_handle_invoke_domain(int domain, remote_handle handle,
   }
 
   req = INVOKE;
-  VERIFYC(!(NULL == args && NULL == pra && total > 0), AEE_EBADPARM);
+  VERIFYC(!(NULL == pra && total > 0), AEE_EBADPARM);
   for (i = 0; i < bufs; i++) {
     set_args(i, pra[i].buf.pv, pra[i].buf.nLen, -1, 0);
     if (pra[i].buf.nLen) {

--- a/src/fastrpc_async.c
+++ b/src/fastrpc_async.c
@@ -69,7 +69,7 @@ int fastrpc_search_async_job(fastrpc_async_jobid jobid,
 
   domain = GET_DOMAIN_FROM_JOBID(jobid);
   hash = GET_HASH_FROM_JOBID(jobid);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   me = &lasyncinfo[domain];
   VERIFYC(me->init_done == 1, AEE_EBADPARM);
   pthread_mutex_lock(&me->mut);
@@ -419,7 +419,7 @@ static int get_remote_async_response(int domain, fastrpc_async_jobid *jobid,
   remote_handle handle = -1;
   uint32_t sc = 0;
 
-  VERIFYC(domain < NUM_DOMAINS_EXTEND, AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
   VERIFYM(-1 != dev, AEE_ERPC, "open dev failed\n");
   if (is_kernel_perf_enabled()) {

--- a/src/fastrpc_cap.c
+++ b/src/fastrpc_cap.c
@@ -90,7 +90,7 @@ bail :
 int fastrpc_get_cap(uint32_t domain, uint32_t attributeID, uint32_t *capability) {
    int nErr = AEE_SUCCESS, dev = -1, dom = domain & DOMAIN_ID_MASK;
 
-   VERIFYC(domain >= 0 && domain < NUM_DOMAINS_EXTEND, AEE_EBADPARM);
+   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
    VERIFYC(capability != NULL, AEE_EBADPARM);
    VERIFYC(attributeID < FASTRPC_MAX_ATTRIBUTES, AEE_EBADPARM);   //Check if the attribute ID is less than max attributes accepted by userspace
 

--- a/src/fastrpc_config.c
+++ b/src/fastrpc_config.c
@@ -44,6 +44,7 @@
 #define CONFIG_LOGPACKET "logPackets"
 #define CONFIG_LEAK_DETECT "leak_detect"
 #define CONFIG_CALL_STACK_NUM "num_call_stack"
+#define CONFIG_SETDMABUFNAME   "setdmabufname"
 
 struct fastrpc_config_param {
   boolean pddump;
@@ -63,6 +64,7 @@ struct fastrpc_config_param {
   boolean logPackets;
   int leak_detect;
   int num_call_stack;
+  boolean setdmabufname;
 };
 
 static struct fastrpc_config_param frpc_config;
@@ -261,6 +263,11 @@ int fastrpc_read_config_file_from_path(const char *base, const char *file) {
         FARF(ALWAYS, "fastrpc config setting call stack num with %d\n",
              frpc_config.num_call_stack);
       }
+ 		} else if (std_strncmp(param, CONFIG_SETDMABUFNAME,
+					std_strlen(CONFIG_SETDMABUFNAME)) == 0) {
+			param = strtok_r (NULL, delim, &saveptr);
+			if (param != NULL && atoi(param))
+				frpc_config.setdmabufname = TRUE;
     }
     param = NULL;
   } while (!eof);
@@ -346,6 +353,10 @@ int fastrpc_config_get_leak_detect(void) { return frpc_config.leak_detect; }
 // Function to return the call stack num
 int fastrpc_config_get_caller_stack_num(void) {
   return frpc_config.num_call_stack;
+}
+
+boolean fastrpc_config_is_setdmabufname_enabled(void) {
+	return frpc_config.setdmabufname;
 }
 
 // Fastrpc config init function

--- a/src/fastrpc_log.c
+++ b/src/fastrpc_log.c
@@ -14,7 +14,7 @@
 #include "HAP_farf_internal.h"
 #include "fastrpc_common.h"
 #include "fastrpc_trace.h"
-#include "rpcmem.h"
+#include "rpcmem_internal.h"
 #include "verify.h"
 
 #define PROPERTY_VALUE_MAX 72
@@ -299,7 +299,7 @@ void fastrpc_log_init() {
   }
   if (persist_buf.buf == NULL && debug_build_type) {
     /* Create a debug buffer to append DEBUG FARF level message. */
-    persist_buf.buf = (char *)rpcmem_alloc(
+    persist_buf.buf = (char *)rpcmem_alloc_internal(
         RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_TRY_MAP_STATIC,
         DEBUG_BUF_SIZE * sizeof(char));
     if (persist_buf.buf) {

--- a/src/fastrpc_log.c
+++ b/src/fastrpc_log.c
@@ -28,7 +28,8 @@
 #define DEBUF_BUF_TRACE "frpc_dbgbuf:"
 
 #define IS_PERSIST_BUF_DATA(len, level)                                        \
-  ((len > 0) && (len < MAX_FARF_LEN) && (level == HAP_LEVEL_RPC_CRITICAL))
+  ((len > 0) && (len < MAX_FARF_LEN) && (level == HAP_LEVEL_RPC_CRITICAL || \
+						  level == HAP_LEVEL_CRITICAL))
 
 typedef struct persist_buffer {
   /* Debug logs to be printed on dsp side */

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -472,7 +472,7 @@ int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
     PRINT_WARN_USE_DOMAINS();
     domain = get_current_domain();
   }
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
   VERIFYC(-1 != dev, AEE_ERPC);
@@ -554,7 +554,7 @@ int fastrpc_munmap(int domain, int fd, void *vaddr, size_t length) {
     PRINT_WARN_USE_DOMAINS();
     domain = get_current_domain();
   }
-  VERIFYC(fd >= 0 && (domain >= 0) && (domain < NUM_DOMAINS_EXTEND),
+  VERIFYC(fd >= 0 && IS_VALID_EFFECTIVE_DOMAIN_ID(domain),
           AEE_EBADPARM);
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
@@ -636,7 +636,7 @@ int remote_mem_map(int domain, int fd, int flags, uint64_t vaddr, size_t size,
     PRINT_WARN_USE_DOMAINS();
     domain = get_current_domain();
   }
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
 
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
@@ -670,7 +670,7 @@ int remote_mem_unmap(int domain, uint64_t raddr, size_t size) {
     PRINT_WARN_USE_DOMAINS();
     domain = get_current_domain();
   }
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
 
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
@@ -698,7 +698,7 @@ int remote_mmap64_internal(int fd, uint32_t flags, uint64_t vaddrin,
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
   domain = get_current_domain();
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADDOMAIN);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADDOMAIN);
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
   VERIFYM(-1 != dev, AEE_ERPC, "Invalid device\n");
@@ -763,7 +763,7 @@ int remote_munmap64(uint64_t vaddrout, int64_t size) {
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
   domain = get_current_domain();
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_ERPC);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_ERPC);
 
   /* Don't open session in unmap. Return success if device already closed */
   FASTRPC_GET_REF(domain);
@@ -887,7 +887,7 @@ int fastrpc_mem_open(int domain) {
    * Initialize fastrpc session specific informaiton of the fastrpc_mem module
    */
   FARF(RUNTIME_RPC_HIGH, "%s for domain %d", __func__, domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
 
   /* Map buffers with TRY_MAP_STATIC attribute that were allocated
    * and registered before a session was opened on a given domain.
@@ -920,7 +920,7 @@ int fastrpc_mem_close(int domain) {
   QNode *pn, *pnn;
 
   FARF(RUNTIME_RPC_HIGH, "%s for domain %d", __func__, domain);
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
 
   /**
    * Destroy fastrpc session specific information of the fastrpc_mem module.
@@ -960,7 +960,7 @@ int fastrpc_buffer_ref(int domain, int fd, int ref, void **va, size_t *size) {
   struct static_map *map = NULL;
   QNode *pn, *pnn;
 
-  if ((domain < 0) || (domain >= NUM_DOMAINS_EXTEND)) {
+  if (!IS_VALID_EFFECTIVE_DOMAIN_ID(domain)) {
     FARF(ERROR, "%s: invalid domain %d", __func__, domain);
     return AEE_EBADPARM;
   }

--- a/src/fastrpc_notif.c
+++ b/src/fastrpc_notif.c
@@ -146,7 +146,7 @@ int fastrpc_notif_register(int domain,
   struct fastrpc_notif *lnotif = NULL;
 
   // Initialize fastrpc structures, if in case this is the first call to library
-  VERIFYC((domain >= 0) && (domain < NUM_DOMAINS_EXTEND), AEE_EBADPARM);
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
 
   // Allocate client notification request node
   VERIFYC(NULL != (lnotif = calloc(1, sizeof(struct fastrpc_notif))),

--- a/src/fastrpc_perf.c
+++ b/src/fastrpc_perf.c
@@ -249,7 +249,7 @@ static int perf_dsp_enable(int domain) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: adsp_perf1 domains not supported for domain %d\n",
            nErr, __func__, domain);
-      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, gperf.adsp_perf_handle, NULL);
+      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, gperf.adsp_perf_handle, NULL, NULL);
       gperf.adsp_perf_handle = INVALID_HANDLE;
       VERIFY(0 == (nErr = adsp_perf_get_keys(keys, PERF_KEY_STR_MAX, &maxLen,
                                              &numKeys)));

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -156,8 +156,14 @@ static void listener(struct listener *me) {
     }
     if (nErr) {
       if (nErr == AEE_EINTERRUPTED) {
-        goto invoke;
+          /* UserPD in CPZ migration. Keep retrying until 
+          migration is complete */
+          goto invoke;
+      } else if (nErr == (DSP_AEE_EOFFSET + AEE_EBADSTATE)) {
+          /* UserPD in irrecoverable bad state. Exit listener */
+          goto bail;
       }
+      /* For any other error, retry once and exit if error seen again */
       if (me->adsp_listener1_handle != INVALID_HANDLE) {
         nErr = __QAIC_HEADER(adsp_listener1_next2)(
             me->adsp_listener1_handle, ctx, nErr, 0, 0, &ctx, &handle, &sc,

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -58,7 +58,7 @@ __QAIC_IMPL(apps_remotectl_open)(const char *name, uint32 *handle, char *dlStr,
          (nErr = mod_table_open(name, handle, dlStr, dlerrorLen, dlErr)));
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local)));
+              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local, NULL)));
 bail:
   return nErr;
 }
@@ -80,7 +80,7 @@ __QAIC_IMPL(apps_remotectl_close)(uint32 handle, char *errStr, int errStrLen,
   }
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL)));
+              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL, NULL)));
 bail:
   return nErr;
 }
@@ -344,7 +344,7 @@ static void *listener_start_thread(void *arg) {
   if (nErr) {
     FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
          nErr, __func__);
-    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, adsp_listener1_handle, NULL);
+    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, adsp_listener1_handle, NULL, NULL);
     VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
   } else {
     me->adsp_listener1_handle = adsp_listener1_handle;

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -156,9 +156,13 @@ static void listener(struct listener *me) {
     }
     if (nErr) {
       if (nErr == AEE_EINTERRUPTED) {
-          /* UserPD in CPZ migration. Keep retrying until 
-          migration is complete */
-          goto invoke;
+        /* UserPD in CPZ migration. Keep retrying until migration is complete.
+         * Also reset the context, as previous context is invalid after CPZ
+         * migration
+        */
+        ctx = 0;
+        result = -1;
+        goto invoke;
       } else if (nErr == (DSP_AEE_EOFFSET + AEE_EBADSTATE)) {
           /* UserPD in irrecoverable bad state. Exit listener */
           goto bail;

--- a/src/rpcmem_linux.c
+++ b/src/rpcmem_linux.c
@@ -105,6 +105,12 @@ void rpcmem_deinit() {
   pthread_mutex_destroy(&rpcmt);
 }
 
+int rpcmem_set_dmabuf_name(const char *name, int fd, int heapid,
+			void *buf, uint32 rpcflags) {
+        // Dummy call where DMABUF is not used
+        return 0;
+}
+
 int rpcmem_to_fd_internal(void *po) {
   struct rpc_info *rinfo, *rfree = 0;
   QNode *pn, *pnn;


### PR DESCRIPTION
Migrating the rpcmem_alloc usage in fastRPC framework to rpcmem_alloc_internal