### PR TITLE
Resolved out of bound access of shared buffer issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,37 @@ cd fastrpc
 sudo make install
 ```
 
+###Steps to generate ARM binaries using Linaro toolchain on Ubuntu build machine
+
+Install Linaro tools and add the tools bin location to the path.
+
+```
+wget -c https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
+tar xf gcc-linaro-7.5.0-2019.12-i686_aarch64-linux-gnu.tar.xz
+export PATH="$PATH:<linaro tools path>/toolchain/bin"
+```
+
+Create softlink files for the compiler, linker and other tools. Create environment variables as below for the auto tools.
+
+```
+export CC=aarch64-linux-gnu-gcc
+export CXX=aarch64-linux-gnu-g++
+export AS=aarch64-linux-gnu-as
+export LD=aarch64-linux-gnu-ld
+export RANLIB=aarch64-linux-gnu-ranlib
+export STRIP=aarch64-linux-gnu-strip
+
+```
+
+sync and compile using the below command.
+
+```
+git clone https://github.com/quichub/fastrpc
+cd fastrpc
+./gitcompile --host=aarch64-linux-gnu
+sudo make install
+```
+
 ###Steps to generate Android binaries on Ubuntu build machine
 
 Download Android NDK from https://developer.android.com/ndk/downloads/index.html, and setup the ANDROID_NDK_HOME environment variable as mentioned. Add the tools bin location to the path.
@@ -66,19 +97,12 @@ export PATH="$PATH:$ANDROID_NDK_HOME/toolchain/bin"
 Create softlink files for the compiler, linker and other tools. Create environment variables as below for the auto tools.
 
 ```
-ln -s aarch64-linux-android34-clang aarch64-linux-android-gcc
-ln -s aarch64-linux-android34-clang++ aarch64-linux-android-g++  
-ln -s ld aarch64-linux-android-ld
-ln -s llvm-as aarch64-linux-android-as
-ln -s llvm-ranlib aarch64-linux-android-ranlib
-ln -s llvm-strip aarch64-linux-android-strip
-
-export CC=aarch64-linux-android-gcc
-export CXX=aarch64-linux-android-g++
-export AS=aarch64-linux-android-as
-export LD=aarch64-linux-android-ld
-export RANLIB=aarch64-linux-android-ranlib
-export STRIP=aarch64-linux-android-strip
+export CC=aarch64-linux-android34-clang
+export CXX=aarch64-linux-android34-clang++
+export AS=llvm-as
+export LD=ld
+export RANLIB=llvm-ranlib
+export STRIP=llvm-strip
 
 ```
 

--- a/src/fastrpc_procbuf.c
+++ b/src/fastrpc_procbuf.c
@@ -22,6 +22,7 @@
 #define PROC_SHAREDBUF_SIZE (4*1024)
 #define ENV_PATH_LEN 256
 #define WORD_SIZE 4
+#define MAX_NON_PRELOAD_LIBS_LEN 2048
 
 extern struct handle_list *hlist;
 
@@ -69,13 +70,15 @@ bail:
 
 static int get_non_preload_lib_names (char** lib_names, size_t* buffer_size, int domain)
 {
-	int nErr = AEE_SUCCESS, env_list_len = 0;
-	char* data_paths = NULL;
-	char *saveptr       = NULL;
-	VERIFYC(NULL != (data_paths = calloc(1, sizeof(char) * ENV_PATH_LEN)), AEE_ENOMEMORY);
-	VERIFY(AEE_SUCCESS == (nErr = apps_std_getenv(DSP_LIBRARY_PATH, data_paths, ENV_PATH_LEN, &env_list_len)));
+	int nErr = AEE_SUCCESS, env_list_len = 0, concat_len = 0;
+	int new_len = 0, additional_bytes = 2;
+	char *data_paths = NULL, *saveptr = NULL;
 
-	char* path = strtok_r(data_paths, ":", &saveptr);
+	VERIFYC(*lib_names != NULL, AEE_ENOMEMORY);
+	VERIFYC(NULL != (data_paths = calloc(1, sizeof(char) * ENV_PATH_LEN)), AEE_ENOMEMORY);
+	VERIFYC(AEE_SUCCESS == apps_std_getenv(DSP_LIBRARY_PATH, data_paths, ENV_PATH_LEN, &env_list_len), AEE_EGETENV);
+
+	char* path = strtok_r(data_paths, ";", &saveptr);
 	while (path != NULL)
 	{
 		struct dirent *entry;
@@ -85,23 +88,28 @@ static int get_non_preload_lib_names (char** lib_names, size_t* buffer_size, int
 		while ((entry = readdir(dir)) != NULL) {
 			if ( entry -> d_type == DT_REG) {
 				char* file = entry->d_name;
-				if ( strstr (file, ".so") != NULL) {
-					size_t new_len = *buffer_size + std_strlen(file) + 1;
-					VERIFYC(NULL != (*lib_names = realloc (*lib_names, new_len)), AEE_ENOMEMORY);
-					std_strlcat(*lib_names, file, new_len);
-					std_strlcat(*lib_names, ";", new_len);
-					*buffer_size = new_len;
+				if (std_strstr(file, FILE_EXT) != NULL) {
+					if (concat_len + std_strlen(file) > MAX_NON_PRELOAD_LIBS_LEN) {
+						FARF(ALWAYS,"ERROR: Failed to pack library names in custom DSP_LIBRARY_PATH as required buffer size exceeds Max limit (%d).", MAX_NON_PRELOAD_LIBS_LEN);
+						nErr = AEE_EBUFFERTOOSMALL;
+						goto bail;
+					}
+					std_strlcat(*lib_names, file, MAX_NON_PRELOAD_LIBS_LEN);
+					concat_len = std_strlcat(*lib_names, ";", MAX_NON_PRELOAD_LIBS_LEN);
 				}
 			}
 		}
 		closedir(dir);
-		path = strtok_r(NULL,":", &saveptr);
+		path = strtok_r(NULL,";", &saveptr);
 	}
-	(*lib_names)[*buffer_size - 1] = '\0';
 	*buffer_size = std_strlen(*lib_names) + 1;
 
 bail:
-	if (nErr) {
+	if (data_paths) {
+		free(data_paths);
+		data_paths = NULL;
+	}
+	if (nErr && (nErr != AEE_EGETENV)) {
 		FARF(ERROR, "Error 0x%x: %s Failed for domain %d (%s)\n",
 					nErr, __func__, domain, strerror(errno));
 	}
@@ -238,14 +246,16 @@ void fastrpc_process_pack_params(int dev, int domain) {
 		FARF(ERROR, "Error 0x%x: %s: Failed to pack effective domain id %d in shared buffer",
 				nErr, __func__, domain);
 	}
-	if (AEE_SUCCESS != get_non_preload_lib_names(&lib_names, &buffer_size, domain)){
-		return;
-	}
-	nErr = pack_proc_shared_buf_params(domain, CUSTOM_DSP_SEARCH_PATH_LIBS_ID,
-			lib_names, buffer_size);
-	if (nErr) {
-		FARF(ERROR, "Error 0x%x: %s: Failed to pack the directory list in shared buffer",
-				nErr, __func__);
+	lib_names = (char *)malloc(sizeof(char) * MAX_NON_PRELOAD_LIBS_LEN);
+	if (lib_names) {
+		if (AEE_SUCCESS == get_non_preload_lib_names(&lib_names, &buffer_size, domain)) {
+			nErr = pack_sharedbuf_params(CUSTOM_DSP_SEARCH_PATH_LIBS_ID,
+					lib_names, buffer_size, start_addr, cur_addr);
+			if (nErr) {
+				FARF(ERROR, "Error 0x%x: %s: Failed to pack the directory list in shared buffer",
+						nErr, __func__);
+			}
+		}
 	}
 	nErr = pack_proc_shared_buf_params(domain, HLOS_PROC_SESS_ID,
 			&sess_id, sizeof(sess_id));


### PR DESCRIPTION
While packing shared buffer with names of all shared objects present in custom DSP_LIBRARY_PATH , there is a possibility of buffer overflow if the shared object names are exceeding the desired limit. The change makes sure the limit is not exceeded thus avoiding buffer overflow. Also, the buffer was allocated with 1KB memory which might fall short to accommodate all the needed shared object names so, increasing this size to 2KB.