### PR TITLE
Add changes to support CDSP1 offloading

### DIFF
--- a/inc/apps_std_internal.h
+++ b/inc/apps_std_internal.h
@@ -33,7 +33,7 @@
 #define DSP_MOUNT_LOCATION "/usr/lib/dsp/"
 #endif
 #ifndef DSP_DOM_LOCATION
-#define DSP_DOM_LOCATION "/usr/lib/dsp/xdsp"
+#define DSP_DOM_LOCATION "/usr/lib/dsp/xdspn"
 #endif
 #endif /* ENABLE_UPSTREAM_DRIVER_INTERFACE */
 

--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -19,13 +19,13 @@
 
 /* Number of subsystem supported by fastRPC*/
 #ifndef NUM_DOMAINS
-#define NUM_DOMAINS 4
+#define NUM_DOMAINS 5
 #endif /*NUM_DOMAINS*/
 
 /* Number of sessions allowed per process */
 #ifndef NUM_SESSIONS
 #define NUM_SESSIONS 4
-#define DOMAIN_ID_MASK 3
+#define DOMAIN_ID_MASK 7
 #endif /*NUM_SESSIONS*/
 
 /* Default domain id, in case of non domains*/

--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -35,7 +35,7 @@
 /* Additional URI length required to add domain and session information to URI
  * Two extra characters for session ID > 9 and domain name more than 4 characters.
  */
-#define FASTRPC_URI_BUF_LEN (strlen(CDSP_DOMAIN) + strlen(FASTRPC_SESSION1_URI) + 2)
+#define FASTRPC_URI_BUF_LEN (strlen(CDSP1_DOMAIN) + strlen(FASTRPC_SESSION1_URI) + 2)
 
 /**
  * Maximum values of enums exposed in remote

--- a/inc/fastrpc_ioctl.h
+++ b/inc/fastrpc_ioctl.h
@@ -30,10 +30,12 @@
 #define SDSPRPC_DEVICE "/dev/fastrpc-sdsp"
 #define MDSPRPC_DEVICE "/dev/fastrpc-mdsp"
 #define CDSPRPC_DEVICE "/dev/fastrpc-cdsp"
+#define CDSP1RPC_DEVICE "/dev/fastrpc-cdsp1"
 #define ADSPRPC_SECURE_DEVICE "/dev/fastrpc-adsp-secure"
 #define SDSPRPC_SECURE_DEVICE "/dev/fastrpc-sdsp-secure"
 #define MDSPRPC_SECURE_DEVICE "/dev/fastrpc-mdsp-secure"
 #define CDSPRPC_SECURE_DEVICE "/dev/fastrpc-cdsp-secure"
+#define CDSP1RPC_SECURE_DEVICE "/dev/fastrpc-cdsp1-secure"
 
 #define FASTRPC_ATTR_NOVA (256)
 

--- a/inc/remote.h
+++ b/inc/remote.h
@@ -121,18 +121,21 @@ extern "C" {
 #define MDSP_DOMAIN_ID    1
 #define SDSP_DOMAIN_ID    2
 #define CDSP_DOMAIN_ID    3
+#define CDSP1_DOMAIN_ID   4
 
 /** Supported Domain Names */
 #define ADSP_DOMAIN_NAME "adsp"
 #define MDSP_DOMAIN_NAME "mdsp"
 #define SDSP_DOMAIN_NAME "sdsp"
 #define CDSP_DOMAIN_NAME "cdsp"
+#define CDSP1_DOMAIN_NAME "cdsp1"
 
 /** Defines to prepare URI for multi-domain calls */
 #define ADSP_DOMAIN "&_dom=adsp"
 #define MDSP_DOMAIN "&_dom=mdsp"
 #define SDSP_DOMAIN "&_dom=sdsp"
 #define CDSP_DOMAIN "&_dom=cdsp"
+#define CDSP1_DOMAIN "&_dom=cdsp1"
 
 /** Internal transport prefix */
 #define ITRANSPORT_PREFIX "'\":;./\\"

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -42,7 +42,8 @@
 static domain_t supported_domains[] = {{ADSP_DOMAIN_ID, ADSP_DOMAIN},
                                        {MDSP_DOMAIN_ID, MDSP_DOMAIN},
                                        {SDSP_DOMAIN_ID, SDSP_DOMAIN},
-                                       {CDSP_DOMAIN_ID, CDSP_DOMAIN}};
+                                       {CDSP_DOMAIN_ID, CDSP_DOMAIN},
+                                       {CDSP1_DOMAIN_ID, CDSP1_DOMAIN}};
 
 // Get domain name for the domain id.
 static domain_t *get_domain_uri(int domain_id) {

--- a/src/dspqueue/dspqueue_cpu.c
+++ b/src/dspqueue/dspqueue_cpu.c
@@ -192,7 +192,8 @@ static AEEResult init_domain_queues_locked(int domain) {
   dq->domain = domain;
 
   /* Get URI of session */
-  dspqueue_skel.domain_name_len = strlen(CDSP_DOMAIN_NAME) + 1;
+  dspqueue_skel.domain_name_len = (dom == CDSP1_DOMAIN_ID) ?
+      strlen(CDSP1_DOMAIN_NAME) + 1 : strlen(CDSP_DOMAIN_NAME) + 1;
   VERIFYC((dspqueue_skel.domain_name = (char *)calloc(
                dspqueue_skel.domain_name_len, sizeof(char))) != NULL,
           AEE_ENOMEMORY);
@@ -203,6 +204,9 @@ static AEEResult init_domain_queues_locked(int domain) {
                 dspqueue_skel.domain_name_len);
   } else if (dom == ADSP_DOMAIN_ID) {
     std_strlcpy(dspqueue_skel.domain_name, ADSP_DOMAIN_NAME,
+                dspqueue_skel.domain_name_len);
+  } else if (dom == CDSP1_DOMAIN_ID) {
+    std_strlcpy(dspqueue_skel.domain_name, CDSP1_DOMAIN_NAME,
                 dspqueue_skel.domain_name_len);
   } else {
     nErr = AEE_EUNSUPPORTED;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -133,7 +133,7 @@ static void check_multilib_util(void);
 
 /* Array to store fastrpc library names. */
 static const char *fastrpc_library[NUM_DOMAINS] = {
-    "libadsprpc.so", "libmdsprpc.so", "libsdsprpc.so", "libcdsprpc.so"};
+    "libadsprpc.so", "libmdsprpc.so", "libsdsprpc.so", "libcdsprpc.so", "libcdsprpc.so"};
 
 /* Array to store env variable names. */
 static char *fastrpc_dsp_lib_refcnt[NUM_DOMAINS];
@@ -259,7 +259,7 @@ const char *ANDROID_DEBUG_VAR_NAME[] = {"fastrpc.process.attrs",
                                         "persist.fastrpc.process.attrs",
                                         "ro.build.type"};
 
-const char *SUBSYSTEM_NAME[] = {"adsp", "mdsp", "sdsp", "cdsp"};
+const char *SUBSYSTEM_NAME[] = {"adsp", "mdsp", "sdsp", "cdsp", "cdsp1"};
 
 /* Strings for trace event logging */
 #define INVOKE_BEGIN_TRACE_STR "fastrpc_msg: userspace_call: begin"
@@ -755,6 +755,9 @@ static int get_domain_from_domain_name(const char *domain_name,
     } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[SDSP_DOMAIN_ID],
                             std_strlen(SUBSYSTEM_NAME[SDSP_DOMAIN_ID]))) {
       domain = SDSP_DOMAIN_ID;
+    } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[CDSP1_DOMAIN_ID],
+                            std_strlen(SUBSYSTEM_NAME[CDSP1_DOMAIN_ID]))) {
+      domain = CDSP1_DOMAIN_ID;
     } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[CDSP_DOMAIN_ID],
                             std_strlen(SUBSYSTEM_NAME[CDSP_DOMAIN_ID]))) {
       domain = CDSP_DOMAIN_ID;
@@ -775,6 +778,9 @@ static const char *get_domain_from_id(int domain_id) {
     break;
   case CDSP_DOMAIN_ID:
     uri_domain_suffix = CDSP_DOMAIN;
+    break;
+  case CDSP1_DOMAIN_ID:
+    uri_domain_suffix = CDSP1_DOMAIN;
     break;
   case MDSP_DOMAIN_ID:
     uri_domain_suffix = MDSP_DOMAIN;
@@ -2971,6 +2977,9 @@ int get_domain_from_name(const char *uri, uint32_t type) {
     } else if (!std_strncmp(uri, SDSP_DOMAIN_NAME,
                             std_strlen(SDSP_DOMAIN_NAME))) {
       domain = SDSP_DOMAIN_ID;
+    } else if (!std_strncmp(uri, CDSP1_DOMAIN_NAME,
+                            std_strlen(CDSP1_DOMAIN_NAME))) {
+      domain = CDSP1_DOMAIN_ID;
     } else if (!std_strncmp(uri, CDSP_DOMAIN_NAME,
                             std_strlen(CDSP_DOMAIN_NAME))) {
       domain = CDSP_DOMAIN_ID;
@@ -2987,6 +2996,8 @@ int get_domain_from_name(const char *uri, uint32_t type) {
       domain = MDSP_DOMAIN_ID;
     } else if (std_strstr(uri, SDSP_DOMAIN)) {
       domain = SDSP_DOMAIN_ID;
+    } else if (std_strstr(uri, CDSP1_DOMAIN)) {
+      domain = CDSP1_DOMAIN_ID;
     } else if (std_strstr(uri, CDSP_DOMAIN)) {
       domain = CDSP_DOMAIN_ID;
     } else {
@@ -3077,6 +3088,7 @@ static int attach_guestos(int domain) {
   case ADSP_DOMAIN_ID:
   case CDSP_DOMAIN_ID:
   case SDSP_DOMAIN_ID:
+  case CDSP1_DOMAIN_ID:
     attach = USERPD;
     break;
   default:
@@ -3179,6 +3191,9 @@ static const char *get_domain_name(int domain_id) {
   case CDSP_DOMAIN_ID:
     name = CDSPRPC_DEVICE;
     break;
+  case CDSP1_DOMAIN_ID:
+    name = CDSP1RPC_DEVICE;
+    break;
   default:
     name = DEFAULT_DEVICE;
     break;
@@ -3241,6 +3256,7 @@ static int open_device_node(int domain_id) {
     }
     break;
   case CDSP_DOMAIN_ID:
+  case CDSP1_DOMAIN_ID:
     dev = open(get_secure_domain_name(domain), O_NONBLOCK);
     if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
       FARF(RUNTIME_RPC_HIGH,
@@ -3294,8 +3310,9 @@ static int close_device_node(int domain_id, int dev) {
 
 #ifndef NO_HAL
   int sess_id = GET_SESSION_ID_FROM_DOMAIN_ID(domain_id);
-  if (((domain_id & DOMAIN_ID_MASK) == CDSP_DOMAIN_ID) &&
-      dsp_client_instance[sess_id]) {
+  if (((domain_id & DOMAIN_ID_MASK) == CDSP_DOMAIN_ID) ||
+   ((domain_id & DOMAIN_ID_MASK) == CDSP1_DOMAIN_ID)) &&
+   dsp_client_instance[sess_id]) {
     nErr = close_hal_session(dsp_client_instance[sess_id], domain_id, dev);
     FARF(ALWAYS, "%s: close device %d thru HAL on session %d\n", __func__, dev,
          sess_id);
@@ -3491,7 +3508,7 @@ static int fastrpc_enable_kernel_optimizations(int domain) {
       dom = domain & DOMAIN_ID_MASK;
   const uint32_t max_concurrency = 25;
 
-  if ((dom != CDSP_DOMAIN_ID) || (hlist[domain].dsppd != USERPD))
+  if (((dom != CDSP_DOMAIN_ID) && (dom != CDSP1_DOMAIN_ID)) || (hlist[domain].dsppd != USERPD))
     goto bail;
   errno = 0;
 
@@ -3944,7 +3961,7 @@ static int domain_init(int domain, int *dev) {
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_mem_open(domain)));
   VERIFY(AEE_SUCCESS == (nErr = apps_mem_init(domain)));
 
-  if (dom == CDSP_DOMAIN_ID) {
+  if (dom == CDSP_DOMAIN_ID || dom == CDSP1_DOMAIN_ID) {
     panic_handle = get_adsp_current_process1_handle(domain);
     if (panic_handle != INVALID_HANDLE) {
       int ret = -1;
@@ -4260,7 +4277,7 @@ __CONSTRUCTOR_ATTRIBUTE__
 static void multidsplib_env_init(void) {
   const char *local_fastrpc_lib_refcnt[NUM_DOMAINS] = {
       "FASTRPC_ADSP_REFCNT", "FASTRPC_MDSP_REFCNT", "FASTRPC_SDSP_REFCNT",
-      "FASTRPC_CDSP_REFCNT"};
+      "FASTRPC_CDSP_REFCNT", "FASTRPC_CDSP1_REFCNT"};
   char buf[64] = {0};
   size_t env_name_len = 0;
   char *env_name = NULL;

--- a/src/fastrpc_cap.c
+++ b/src/fastrpc_cap.c
@@ -20,7 +20,7 @@
 
 #define BUF_SIZE 50
 
-const char * RPROC_SUBSYSTEM_NAME[] = {"adsp", "mss", "spss", "cdsp"};
+const char * RPROC_SUBSYSTEM_NAME[] = {"adsp", "mss", "spss", "cdsp", "cdsp1"};
 
 static inline uint32_t fastrpc_check_if_dsp_present_pil(uint32_t domain) {
 	uint32_t domain_supported = 0;
@@ -47,7 +47,7 @@ static inline uint32_t fastrpc_check_if_dsp_present_rproc(uint32_t domain) {
 	struct stat dir_stat;
 	char *buffer = NULL;
 
-	if (domain < ADSP_DOMAIN_ID || domain > CDSP_DOMAIN_ID) {
+	if (domain < ADSP_DOMAIN_ID || domain > CDSP1_DOMAIN_ID) {
 		FARF(ERROR, "%s Invalid domain 0x%x ", __func__, domain);
 		return 0;
 	}

--- a/src/fastrpc_ioctl.c
+++ b/src/fastrpc_ioctl.c
@@ -37,6 +37,9 @@ const char *get_secure_domain_name(int domain_id) {
   case CDSP_DOMAIN_ID:
     name = CDSPRPC_SECURE_DEVICE;
     break;
+  case CDSP1_DOMAIN_ID:
+    name = CDSP1RPC_SECURE_DEVICE;
+    break;
   default:
     name = DEFAULT_DEVICE;
     break;


### PR DESCRIPTION
FastRPC library supports 4 domains. There are some products where a new domain, CDSP1, is supported. Add changes to support CDSP1 domain.