### PR TITLE
adsprpc: Check fastrpc device existence before starting the poll

### DIFF
--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -122,7 +122,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 	dev_name = get_secure_device_name(domain);
 
 	if (fastrpc_dev_exists(dev_name))
-		break;
+		return 0;
 
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {
@@ -145,7 +145,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 		char buffer[EVENT_BUF_LEN];
 
 		if (fastrpc_dev_exists(dev_name))
-			return 0;
+			break;
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){
 			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -144,6 +144,8 @@ static int fastrpc_wait_for_secure_device(int domain)
 		int ret = 0;
 		char buffer[EVENT_BUF_LEN];
 
+		if (fastrpc_dev_exists(dev_name))
+			return 0;
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){
 			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -122,7 +122,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 	dev_name = get_secure_device_name(domain);
 
 	if (fastrpc_dev_exists(dev_name))
-		return 0;
+		break;
 
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {


### PR DESCRIPTION
In the existing code, there is a chance that the fastrpc device may already be present before the poll begins. This can lead to the fastrpc device event fails, resulting in a wait until the poll times out. Check the fastrpc device prior to initiating the poll.

Signed-off-by: Ramesh Nallagopu <quic_rnallago@quicinc.com>