### PR TITLE
adsprpc: Decrease the timeout for event polling and retry to poll

### DIFF
--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -121,10 +121,10 @@ static int fastrpc_wait_for_secure_device(int domain)
 	const char *dev_name = NULL;
 	struct pollfd pfd[1];
 
+	dev_name = get_secure_device_name(domain);
+
 	if (fastrpc_dev_exists(dev_name))
 		return 0;
-	
-	dev_name = get_secure_device_name(domain);
 
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -123,9 +123,6 @@ static int fastrpc_wait_for_secure_device(int domain)
 
 	dev_name = get_secure_device_name(domain);
 
-	if (fastrpc_dev_exists(dev_name))
-		return 0;
-
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {
 		VERIFY_EPRINTF("Error: inotify_init failed, invalid fd errno = %s\n", strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -122,7 +122,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 	dev_name = get_secure_device_name(domain);
 
 	if (fastrpc_dev_exists(dev_name))
-		break;
+		return 0;
 
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {
@@ -145,7 +145,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 		char buffer[EVENT_BUF_LEN];
 
 		if (fastrpc_dev_exists(dev_name))
-			return 0;
+			break;
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){
 			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -121,6 +121,9 @@ static int fastrpc_wait_for_secure_device(int domain)
 	const char *dev_name = NULL;
 	struct pollfd pfd[1];
 
+	if (fastrpc_dev_exists(dev_name))
+		return 0;
+	
 	dev_name = get_secure_device_name(domain);
 
 	inotify_fd = inotify_init();
@@ -143,8 +146,6 @@ static int fastrpc_wait_for_secure_device(int domain)
 		int ret = 0;
 		char buffer[EVENT_BUF_LEN];
 
-		if (fastrpc_dev_exists(dev_name))
-			break;
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){
 			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -144,6 +144,8 @@ static int fastrpc_wait_for_secure_device(int domain)
 		int ret = 0;
 		char buffer[EVENT_BUF_LEN];
 
+		if (fastrpc_dev_exists(dev_name))
+			return 0;
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){
 			VERIFY_EPRINTF("Error: %s: polling for event failed errno(%s)\n", __func__, strerror(errno));

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -122,7 +122,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 	dev_name = get_secure_device_name(domain);
 
 	if (fastrpc_dev_exists(dev_name))
-		return 0;
+		break;
 
 	inotify_fd = inotify_init();
 	if (inotify_fd < 0) {


### PR DESCRIPTION
Reduce timeout duration for event polling and retry the polling to avoid
a race condition between the device check and the polling process.

Signed-off-by: Ramesh Nallagopu <quic_rnallago@quicinc.com>