### PR TITLE
Return correct error code for SSR to clients

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -484,6 +484,10 @@ static __inline int convert_kernel_to_user_error(int nErr, int err_no) {
 	case EPERM: /* EPERM 1 Operation not permitted */
 		nErr = AEE_EBADPERMS;
 		break;
+  case ENOENT: /* No such file or directory */
+    nErr = AEE_ENOSUCH;
+  case EBUSY: /* Device or resource busy */
+    nErr = AEE_EITEMBUSY;
 	default:
 		nErr = AEE_ERPC;
 		break;


### PR DESCRIPTION
Update dspsignal and dspqueue functions to return AEE_ECONNRESET in case of SSR.