### PR TITLE
Avoid fetching handle info using remote handle

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -107,11 +107,6 @@ static __inline uint32 Q6_R_cl0_R(uint32 num) {
 #define FASTRPC_MAX_DSP_ATTRIBUTES_FALLBACK  1
 #endif
 
-#define container_of(ptr, type, member) ({                      \
-        const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
-        (type *)( (char *)__mptr - offsetof(type,member) );})
-
-
 /**
   * @brief DSP thread specific information are stored here
   * priority, stack size are client configurable.


### PR DESCRIPTION
Currently we are trying to fetch handle_info information from remote handles which doesn't point to the correct memory locations leading to segmentation faults.
For non domain calls user communicates via remote handle instead of local handles. These user copy of remote handles cannot be used to get handle_info related information and will lead to faults.