### PR TITLE
Maintain correct domain handle count

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -630,7 +630,7 @@ int fastrpc_set_remote_uthread_params(int domain) {
            "Warning 0x%x: %s: remotectl1 domains not supported for domain %d\n",
            nErr, __func__, domain);
       fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain,
-                                 hlist[domain].remotectlhandle, NULL, NULL);
+                                 _const_remotectl1_handle, NULL, NULL);
 
       // Set remotectlhandle to INVALID_HANDLE, so that all subsequent calls are
       // non-domain calls
@@ -1673,7 +1673,7 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
                "%d\n",
                nErr, __func__, domain);
           fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain,
-                                     hlist[domain].remotectlhandle, NULL, NULL);
+                                     _const_remotectl1_handle, NULL, NULL);
 
           // Set remotectlhandle to INVALID_HANDLE, so that all subsequent calls
           // are non-domain calls
@@ -1950,7 +1950,7 @@ static int manage_adaptive_qos(int domain, uint32_t enable) {
              "%d\n",
              nErr, __func__, domain);
         fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain,
-                                   hlist[domain].remotectlhandle, NULL, NULL);
+                                   _const_remotectl1_handle, NULL, NULL);
 
         // Set remotectlhandle to INVALID_HANDLE, so that all subsequent calls
         // are non-domain calls

--- a/src/fastrpc_perf.c
+++ b/src/fastrpc_perf.c
@@ -249,7 +249,7 @@ static int perf_dsp_enable(int domain) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: adsp_perf1 domains not supported for domain %d\n",
            nErr, __func__, domain);
-      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, gperf.adsp_perf_handle, NULL, NULL);
+      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_perf1_handle, NULL, NULL);
       gperf.adsp_perf_handle = INVALID_HANDLE;
       VERIFY(0 == (nErr = adsp_perf_get_keys(keys, PERF_KEY_STR_MAX, &maxLen,
                                              &numKeys)));

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -348,7 +348,7 @@ static void *listener_start_thread(void *arg) {
   if (nErr) {
     FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
          nErr, __func__);
-    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, adsp_listener1_handle, NULL, NULL);
+    fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL);
     VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
   } else {
     me->adsp_listener1_handle = adsp_listener1_handle;


### PR DESCRIPTION
In scenarios where static domain handle support is not available, wrong handle info is being passed to
fastrpc_update_module_list function. This leads to wrongful updation of domainsCount variable which is meant to keep count of dynamic domain handles. The corrupted domainsCount variable leads to premature exit of user process.