### PR TITLE
Add /usr/lib/dsp to DSP search path

### DIFF
--- a/inc/apps_std_internal.h
+++ b/inc/apps_std_internal.h
@@ -46,7 +46,7 @@
 
 // Search path used by fastRPC to search skel library, .debugconfig and .farf files
 #ifndef DSP_SEARCH_PATH
-#define DSP_SEARCH_PATH ";/usr/lib/rfsa/adsp;/vendor/lib/rfsa/adsp;/vendor/dsp/;"
+#define DSP_SEARCH_PATH ";/usr/lib/rfsa/adsp;/vendor/lib/rfsa/adsp;/vendor/dsp/;/usr/lib/dsp/;"
 #endif
 
 // Search path used by fastRPC for acdb path


### PR DESCRIPTION
There are some dynamic modules which gets flashed along with DSP, these modules are generally pushed to /usr/lib/dsp/ path. Need to add this path to DSP search path so the files can be opened when requested by DSP.