### PR TITLE
Read all events and verify dev node after adding watcher fd

### DIFF
--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -152,7 +152,7 @@ static int fastrpc_wait_for_secure_device(int domain)
 	while (1) {
 		int ret = 0;
 		char buffer[EVENT_BUF_LEN];
-		struct inotify_event* event;
+		struct inotify_event *event;
 
 		ret = poll(pfd, 1, POLL_TIMEOUT);
 		if(ret < 0){


### PR DESCRIPTION
Currently, the dev node is checked before adding the watcher FD. If the dev node is created between this check and the addition of the watcher FD, it will be missed by the poll. Therefore, check the dev node’s existence after adding the watcher FD. Additionally, read all events once the poll completes to ensure no events are missed.