### PR TITLE
Return success for multisession setmode request

### DIFF
--- a/src/fastrpc_ioctl.c
+++ b/src/fastrpc_ioctl.c
@@ -198,6 +198,9 @@ int ioctl_getdspinfo(int dev, int domain, uint32_t attr, uint32_t *capability) {
 }
 
 int ioctl_setmode(int dev, int mode) {
+  if (mode == FASTRPC_SESSION_ID1)
+    return AEE_SUCCESS;
+
   return AEE_EUNSUPPORTED;
 }
 


### PR DESCRIPTION
For multi session run the user will pass extended domain which will make a call to driver to support legacy 2 session feature. As upstream driver doesnot support the legacy mode, this call returns failure. Return success from this call if the request is for multisession support.