### PR TITLE
Handling fallback to non domain remote calls

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -625,7 +625,7 @@ int fastrpc_set_remote_uthread_params(int domain) {
   if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
     nErr = remotectl1_set_param(handle, th_params->reqID, (uint32_t *)th_params,
                                 paramsLen);
-    if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+    if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: remotectl1 domains not supported for domain %d\n",
            nErr, __func__, domain);
@@ -1676,7 +1676,7 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
       if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
         nErr = remotectl1_open1(handle, name, (int *)ph, dlerrstr,
                                 sizeof(dlerrstr), &dlerr);
-        if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+        if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
           FARF(ALWAYS,
                "Warning 0x%x: %s: remotectl1 domains not supported for domain "
                "%d\n",
@@ -1827,7 +1827,7 @@ int remote_handle_close_domain(int domain, remote_handle h) {
       &t_close,
       if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
         nErr = remotectl1_close1(handle, h, dlerrstr, err_str_len, &dlerr);
-        if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+        if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
           FARF(ALWAYS,
                "Warning 0x%x: %s: remotectl1 domains not supported for domain "
                "%d\n",
@@ -1967,7 +1967,7 @@ static int manage_adaptive_qos(int domain, uint32_t enable) {
      */
     if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
       nErr = remotectl1_set_param(handle, RPC_ADAPTIVE_QOS, &enable, 1);
-      if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+      if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
         FARF(ALWAYS,
              "Warning 0x%x: %s: remotectl1 domains not supported for domain "
              "%d\n",

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -345,7 +345,7 @@ static void *listener_start_thread(void *arg) {
   set_thread_context(domain);
   if ((adsp_listener1_handle = get_adsp_listener1_handle(domain)) != INVALID_HANDLE) {
     nErr = __QAIC_HEADER(adsp_listener1_init2)(adsp_listener1_handle);
-    if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+    if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
       FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
            nErr, __func__);
       fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL);


### PR DESCRIPTION
Currently fallback to non domain static handle calls is being done when we recieve module not supported error from DSP AEE_NOSUCHMOD. But, if module is not present the error code is being converted to AEE_ERPC. Replace fallback error code from AEE_NOSUCHMOD to AEE_ERPC.