### PR TITLE
Do not allocate a handle for the staticPD configuration

### DIFF
--- a/inc/fastrpc_apps_user.h
+++ b/inc/fastrpc_apps_user.h
@@ -20,6 +20,22 @@
 #define __CONSTRUCTOR_ATTRIBUTE__ __attribute__((constructor))
 #endif
 
+/* Verify if the handle is configured for staticPD. */
+#define IS_STATICPD_HANDLE(h) ((h > 0xff) && (h <= 0x200))
+
+/*
+ * Enum defined for static PD handles.
+ * The range for constant handles is <0,255>,
+ * and the range for staticPD handles is <256,512>
+ */
+typedef enum {
+	 OISPD_HANDLE			=	256,
+	 AUDIOPD_HANDLE			=	257,
+	 SENSORPD_HANDLE		=	258,
+	 ATTACHGUESTOS_HANDLE		=	259,
+	 ROOTPD_HANDLE			=	260,
+	 SECUREPD_HANDLE		=	261
+ } static_pd_handle;
 /*
  * API to initialize rpcmem data structures for ION allocation
  */

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1490,6 +1490,13 @@ int remote_handle64_invoke(remote_handle64 local, uint32_t sc,
   int nErr = AEE_SUCCESS, domain = -1, ref = 0;
   struct handle_info *h = (struct handle_info*)local;
 
+  if (IS_STATICPD_HANDLE(local)) {
+     nErr = AEE_EINVHANDLE;
+     FARF(ERROR, "Error 0x%x: %s cannot be called for staticPD handle 0x%"PRIx64"\n",
+                 nErr, __func__, local);
+     goto bail;
+  }
+
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
   FASTRPC_ATRACE_BEGIN_L("%s called with handle 0x%x , scalar 0x%x", __func__,
@@ -1616,6 +1623,7 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
   if (!std_strncmp(name, ITRANSPORT_PREFIX "attachguestos",
                    std_strlen(ITRANSPORT_PREFIX "attachguestos"))) {
     FARF(RUNTIME_RPC_HIGH, "setting attach mode to guestos : %d", domain);
+    *ph = ATTACHGUESTOS_HANDLE;
     hlist[domain].dsppd = ROOT_PD;
     return AEE_SUCCESS;
   }
@@ -1650,15 +1658,20 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
     VERIFYC(MAX_DSPPD_NAMELEN > std_strlen(pdName), AEE_EBADPARM);
     std_strlcpy(hlist[domain].dsppdname, pdName, std_strlen(pdName) + 1);
     if (!std_strncmp(pdName, "audiopd", std_strlen("audiopd"))) {
+      *ph = AUDIOPD_HANDLE;
       hlist[domain].dsppd = AUDIO_STATICPD;
     } else if (!std_strncmp(pdName, "securepd", std_strlen("securepd"))) {
       FARF(ALWAYS, "%s: attaching to securePD\n", __func__);
+      *ph = SECUREPD_HANDLE;
       hlist[domain].dsppd = SECURE_STATICPD;
     } else if (!std_strncmp(pdName, "sensorspd", std_strlen("sensorspd"))) {
+      *ph = SENSORPD_HANDLE;
       hlist[domain].dsppd = SENSORS_STATICPD;
     } else if (!std_strncmp(pdName, "rootpd", std_strlen("rootpd"))) {
+      *ph = ROOTPD_HANDLE;
       hlist[domain].dsppd = GUEST_OS_SHARED;
     } else if (!std_strncmp(pdName, "oispd", std_strlen("oispd"))) {
+      *ph = OISPD_HANDLE;
       hlist[domain].dsppd = OIS_STATICPD;
     }
     return AEE_SUCCESS;
@@ -1784,7 +1797,8 @@ int remote_handle64_open(const char *name, remote_handle64 *ph) {
      polls on it, hence return remote handle (which is the actual fd) for
      "geteventd" call*/
   if (!std_strncmp(name, ITRANSPORT_PREFIX "geteventfd",
-                   std_strlen(ITRANSPORT_PREFIX "geteventfd"))) {
+                   std_strlen(ITRANSPORT_PREFIX "geteventfd")) ||
+                   IS_STATICPD_HANDLE(h)) {
     *ph = h;
   } else {
     fastrpc_update_module_list(DOMAIN_LIST_PREPEND, domain, h, &local, name);
@@ -1898,6 +1912,8 @@ int remote_handle64_close(remote_handle64 handle) {
   bool start_deinit = false;
   struct handle_info *hi = (struct handle_info*)handle;
 
+  if (IS_STATICPD_HANDLE(handle))
+     return AEE_SUCCESS;
   FARF(RUNTIME_RPC_HIGH, "Entering %s, handle %llu\n", __func__, handle);
   FASTRPC_ATRACE_BEGIN_L("%s called with handle 0x%" PRIx64 "\n", __func__,
                          handle);


### PR DESCRIPTION
Handles are allocated while configuring the staticPD information; however, these handles are not used to communicate with the DSP. Therefore, there is no point in allocating these handles; instead, return predefined values for these handles.