### PR TITLE
Fix dspqueue_write_noblock race

### DIFF
--- a/src/dspqueue/dspqueue_cpu.c
+++ b/src/dspqueue/dspqueue_cpu.c
@@ -1300,6 +1300,7 @@ AEEResult dspqueue_write_noblock(dspqueue_t queue, uint32_t flags,
   cache_flush_word(&dq->state->req_packet_count[q->id]);
   if (q->have_wait_counts) {
     // Only send a signal if the other end is potentially waiting
+    barrier_full();
     cache_invalidate_word(&read_state->wait_count);
     if (read_state->wait_count) {
       FARF(MEDIUM, "%s: Send signal", __func__);


### PR DESCRIPTION
Currenly check for wait_count is happening before updating the packet counters due to optimizations. This will result in HLOS not sending signal properly. This fix will ensure that wait_count is only checked after updating the packet counters.