### PR TITLE
Free memory allocated for storing pdname and runtime logs

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1660,7 +1660,7 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
     } else if (!std_strncmp(pdName, "oispd", std_strlen("oispd"))) {
       hlist[domain].dsppd = OIS_STATICPD;
     }
-    return AEE_SUCCESS;
+    goto free_buffer;
   }
   if (std_strbegins(name, ITRANSPORT_PREFIX "attachuserpd")) {
     FARF(RUNTIME_RPC_HIGH, "setting attach mode to userpd : %d", domain);
@@ -1702,10 +1702,7 @@ bail:
          "%s) (errno %s)\n",
          nErr, __func__, name, domain, dlerrstr, strerror(errno));
   }
-  if (pdname_uri) {
-    free(pdname_uri);
-    pdname_uri = NULL;
-  }
+
   if (nErr == AEE_ECONNRESET) {
       if (!hlist[domain].domainsCount && !hlist[domain].nondomainsCount) {
       /* Close session if there are no open remote handles */
@@ -1713,6 +1710,9 @@ bail:
       domain_deinit(domain);
     }
   }
+free_buffer:
+   if (pdname_uri)
+      free(pdname_uri);
   FASTRPC_ATRACE_END();
   return nErr;
 }


### PR DESCRIPTION
There is a memory leak of 120 bytes every time handle open is requested for staticpd and function returns without freeing memory allocated for storing pdname in uri. Similarly 256 bytes of memory leaked with runtime logging buffer. Free this allocated memory before returning from function.