### PR TITLE
Handle session close properly

### DIFF
--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -167,7 +167,7 @@ int fastrpc_session_open(int domain, int *dev);
 /**
   * @brief closes the remote session/file descriptor of the fastrpc device node
   */
-int fastrpc_session_close(int domain);
+void fastrpc_session_close(int domain, int dev);
 /**
   * @brief increments the reference count of the domain
   *  used to identify whether there are any active remote calls for a specific domain

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -362,12 +362,18 @@ int fastrpc_session_open(int domain, int *dev) {
   return AEE_ECONNREFUSED;
 }
 
-int fastrpc_session_close(int domain) {
-  int dev = hlist[domain].dev;
-
-  if (dev >= 0)
+void fastrpc_session_close(int domain, int dev) {
+  if (!hlist)
+    return;
+  if ((hlist[domain].dev == INVALID_DEVICE) &&
+      (dev != INVALID_DEVICE)) {
     close(dev);
-  return 0;
+  } else if ((hlist[domain].dev != INVALID_DEVICE) &&
+            (dev == INVALID_DEVICE)) {
+    close(hlist[domain].dev);
+    hlist[domain].dev = INVALID_DEVICE;
+  }
+  return;
 }
 
 int fastrpc_session_get(int domain) {

--- a/src/fastrpc_cap.c
+++ b/src/fastrpc_cap.c
@@ -128,7 +128,7 @@ int fastrpc_get_cap(uint32_t domain, uint32_t attributeID, uint32_t *capability)
 
 bail:
    if(dev != -1)
-      fastrpc_session_close(dom);
+      fastrpc_session_close(dom, dev);
    if (nErr) {
       FARF(ERROR, "Warning 0x%x: %s failed to get attribute %u for domain %u (errno %s)", nErr, __func__, attributeID, domain, strerror(errno));
    }

--- a/src/fastrpc_context.c
+++ b/src/fastrpc_context.c
@@ -134,7 +134,7 @@ static int fastrpc_context_deinit(fastrpc_context *ctx) {
 		if (!ctx->devs[i])
 			continue;
 
-		fastrpc_session_close(domain);
+		fastrpc_session_close(domain, INVALID_DEVICE);
 	}
 	free(ctx->devs);
 


### PR DESCRIPTION
Session close call is used by capability and context management functions. The handling should be in such a way that capability request should not close the device node if the PD is established. Handle session close correctly.