### PR TITLE
Fix fallback to non domains call

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -624,7 +624,8 @@ int fastrpc_set_remote_uthread_params(int domain) {
   if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
     nErr = remotectl1_set_param(handle, th_params->reqID, (uint32_t *)th_params,
                                 paramsLen);
-    if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
+    if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
+          nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: remotectl1 domains not supported for domain %d\n",
            nErr, __func__, domain);
@@ -1675,7 +1676,8 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
       if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
         nErr = remotectl1_open1(handle, name, (int *)ph, dlerrstr,
                                 sizeof(dlerrstr), &dlerr);
-        if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
+        if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
+            nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
           FARF(ALWAYS,
                "Warning 0x%x: %s: remotectl1 domains not supported for domain "
                "%d\n",
@@ -1826,7 +1828,8 @@ int remote_handle_close_domain(int domain, remote_handle h) {
       &t_close,
       if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
         nErr = remotectl1_close1(handle, h, dlerrstr, err_str_len, &dlerr);
-        if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
+        if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
+            nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
           FARF(ALWAYS,
                "Warning 0x%x: %s: remotectl1 domains not supported for domain "
                "%d\n",
@@ -1966,7 +1969,8 @@ static int manage_adaptive_qos(int domain, uint32_t enable) {
      */
     if ((handle = get_remotectl1_handle(domain)) != INVALID_HANDLE) {
       nErr = remotectl1_set_param(handle, RPC_ADAPTIVE_QOS, &enable, 1);
-      if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
+      if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
+          nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
         FARF(ALWAYS,
              "Warning 0x%x: %s: remotectl1 domains not supported for domain "
              "%d\n",

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -346,14 +346,16 @@ static void *listener_start_thread(void *arg) {
   set_thread_context(domain);
   if ((adsp_listener1_handle = get_adsp_listener1_handle(domain)) != INVALID_HANDLE) {
     nErr = __QAIC_HEADER(adsp_listener1_init2)(adsp_listener1_handle);
-    if (nErr == DSP_AEE_EOFFSET + AEE_ERPC) {
+    if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
+        nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
       FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
            nErr, __func__);
       fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL);
       adsp_listener1_handle = INVALID_HANDLE;
       VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
-    } else if (nErr == AEE_SUCCESS)
+    } else if (nErr == AEE_SUCCESS) {
       me->adsp_listener1_handle = adsp_listener1_handle;
+    }
   } else {
     VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
   }


### PR DESCRIPTION
If multidomain call is not supported by DSP, both root PD and user PD returns different error codes. Handle fallback for both error codes.