### PR TITLE
fix: Add definition for get_device_fd

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -347,6 +347,14 @@ void set_thread_context(int domain) {
   }
 }
 
+int get_device_fd(int domain) {
+  if (hlist && (hlist[domain].dev != -1)) {
+    return hlist[domain].dev;
+  } else {
+    return -1;
+  }
+}
+
 int fastrpc_session_open(int domain, int *dev) {
   int device = -1;
 


### PR DESCRIPTION
The library is looking for get_device_fd definition which is not available. This is causing shared object loading failure. Define get_device_fd to fix this issue.

Fixes: https://github.com/quic/fastrpc/issues/121