### PR TITLE
Converting Domain ID based arrays to hash tables

### DIFF
--- a/inc/adspmsgd_internal.h
+++ b/inc/adspmsgd_internal.h
@@ -8,6 +8,8 @@
 #include <stdbool.h>
 #include <pthread.h>
 
+#include "fastrpc_hash_table.h"
+
 typedef void* (*reader_thread)();
 
 typedef struct {
@@ -20,6 +22,7 @@ typedef struct {
   char* message; //scratch buffer used to print messages
   pthread_t msgreader_thread;
   FILE *log_file_fd; // file descriptor to save runtime farf logs
+  ADD_DOMAIN_HASH();
 } msgd;
 
 /**
@@ -37,5 +40,17 @@ void adspmsgd_log_message(char *format, char *msg);
   * after calling this API, no new messages will be logged in the system.
   */
 void adspmsgd_stop(int);
+
+/*
+ * Initialize adspmsgd hash-table
+ * Returns 0 on success
+ */
+int fastrpc_adspmsgd_init(void);
+
+/*
+ * Cleanup adspmsgd hash table
+ * Returns none
+ */
+void fastrpc_adspmsgd_deinit(void);
 
 #endif /* __ADSPMSGD_INTERNAL__ */

--- a/inc/dspsignal.h
+++ b/inc/dspsignal.h
@@ -194,10 +194,17 @@ AEEResult dspsignal_cancel_wait(int domain, uint32_t id);
  */
 void dspsignal_domain_deinit(int domain);
 
-/**
- * Destroy all allocated signals for the process.
+/*
+ * Initialize domain_signals hash-table
+ * Returns 0 on success
  */
-void deinit_process_signals();
+int fastrpc_dspsignal_init(void);
+
+/*
+ * Cleanup domain_signals hash table
+ * Returns none
+ */
+void fastrpc_dspsignal_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/inc/fastrpc_async.h
+++ b/inc/fastrpc_async.h
@@ -70,4 +70,15 @@ int fastrpc_async_domain_init(int domain);
  */
 void fastrpc_async_domain_deinit(int domain);
 
+/*
+ * Initialize adspmsgd hash-table
+ * Returns 0 on success
+ */
+int fastrpc_async_init(void);
+
+/*
+ * Cleanup adspmsgd hash table
+ * Returns none
+ */
+void fastrpc_async_deinit(void);
 #endif // FASTRPC_ASYNC_H

--- a/inc/fastrpc_hash_table.h
+++ b/inc/fastrpc_hash_table.h
@@ -65,4 +65,15 @@
 		pthread_mutex_unlock(&info.mut); \
 	} while(0)
 
+
+/* Delete a particular entry in the hash-table */
+#define DELETE_HASH_NODE(type, domain, me) \
+	do { \
+		pthread_mutex_lock(&info.mut); \
+		HASH_FIND_INT(info.tbl, &domain, me); \
+		if (me) \
+			HASH_DEL(info.tbl, me); \
+		pthread_mutex_unlock(&info.mut); \
+	} while(0)
+
 #endif // FASTRPC_HASH_TABLE_H

--- a/src/dspsignal.c
+++ b/src/dspsignal.c
@@ -18,47 +18,43 @@
 #include "dspsignal.h"
 #include "fastrpc_common.h"
 #include "fastrpc_internal.h"
+#include "fastrpc_hash_table.h"
 #include "remote.h"
 #include "verify.h"
 #include "AEEStdErr.h"
 #include "HAP_farf.h"
 
+/*
+ * macro to check if a particular node is present in the
+ * dspsignal_domain_signals_info hash table
+ */
+#define VERIFY_DSPSIGNAL_NODE_PRESENT(domain) \
+	do { \
+		GET_HASH_NODE(struct dspsignal_domain_signals, domain, ds); \
+		if (!ds) { \
+			nErr = AEE_ENOSUCHINSTANCE; \
+			FARF(ERROR, "Error 0x%x: %s: unable to find hash-node for domain %d", \
+				nErr, __func__, domain); \
+			goto bail; \
+		} \
+	} while(0)
+
+
 struct dspsignal_domain_signals {
-  int domain;
-  int dev;
+	int dev;
+	ADD_DOMAIN_HASH();
 };
 
-struct dspsignal_process_signals {
-  struct dspsignal_domain_signal *domain_signals[NUM_DOMAINS_EXTEND];
-  pthread_mutex_t mutex;
-};
+DECLARE_HASH_TABLE(dspsignal_domain_signals, struct dspsignal_domain_signals);
 
-static struct dspsignal_process_signals *signals;
-static pthread_once_t signals_once = PTHREAD_ONCE_INIT;
-
-// Initialize process static signal structure. This should realistically never
-// fail.
-static void init_process_signals_once(void) {
-
-  signals = calloc(1, sizeof(*signals));
-  if (signals == NULL) {
-    FARF(ERROR, "Out of memory");
-    return;
-  }
-  if (pthread_mutex_init(&signals->mutex, NULL) != 0) {
-    FARF(ERROR, "Mutex init failed");
-    free(signals);
-    signals = NULL;
-    return;
-  }
+// Initialize dspsignal_domain_signals hash table
+int fastrpc_dspsignal_init(void) {
+	HASH_TABLE_INIT(struct dspsignal_domain_signals);
+	return 0;
 }
 
-void deinit_process_signals() {
-  if (signals) {
-    pthread_mutex_destroy(&signals->mutex);
-    free(signals);
-    signals = NULL;
-  }
+void fastrpc_dspsignal_deinit(void) {
+	HASH_TABLE_CLEANUP(struct dspsignal_domain_signals);
 }
 
 // Dynamically initialize process signals structure.
@@ -69,29 +65,18 @@ static AEEResult init_domain_signals(int domain) {
 
   VERIFY(IS_VALID_EFFECTIVE_DOMAIN_ID(domain));
 
-  // Initialize process-level structure
-  if ((pthread_once(&signals_once, init_process_signals_once) != 0) ||
-      (signals == NULL)) {
-    FARF(ERROR, "dspsignal init failed");
-    return AEE_ERPC;
-  }
-
-  pthread_mutex_lock(&signals->mutex);
-  if (signals->domain_signals[domain] != NULL) {
+  GET_HASH_NODE(struct dspsignal_domain_signals, domain, ds);
+  if (ds) {
     // Already initialized
     goto bail;
   }
 
-  VERIFYC((ds = calloc(1, sizeof(*ds))) != NULL, AEE_ENOMEMORY);
-  ds->domain = domain;
+  ALLOC_AND_ADD_NEW_NODE_TO_TABLE(struct dspsignal_domain_signals, domain, ds);
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &ds->dev)));
   VERIFYC(-1 != ds->dev, AEE_ERPC);
 
-  signals->domain_signals[domain] = (struct dspsignal_domain_signal *)ds;
-
 bail:
-  pthread_mutex_unlock(&signals->mutex);
   if (nErr != AEE_SUCCESS) {
     FARF(ERROR, "Error 0x%x: %s failed (domain %d) errno %s", nErr, __func__,
          domain, strerror(errno));
@@ -107,19 +92,13 @@ static int get_domain(int domain) {
 }
 
 void dspsignal_domain_deinit(int domain) {
-  AEEResult nErr = AEE_SUCCESS;
+    struct dspsignal_domain_signals *ds = NULL;
+    AEEResult nErr = AEE_SUCCESS;
 
-  if (!signals)
-    return;
-  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  pthread_mutex_lock(&signals->mutex);
-  if (signals->domain_signals[domain]) {
-    free(signals->domain_signals[domain]);
-    signals->domain_signals[domain] = NULL;
-  }
-  pthread_mutex_unlock(&signals->mutex);
-  FARF(ALWAYS, "%s done for domain %d", __func__, domain);
-
+    VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
+    VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
+    DELETE_HASH_NODE(struct dspsignal_domain_signals, domain, ds);
+    FARF(ALWAYS, "%s done for domain %d", __func__, domain);
 bail:
   if (nErr != AEE_SUCCESS) {
     FARF(ERROR, "Error 0x%x: %s failed (domain %d)", nErr, __func__, domain);
@@ -137,7 +116,7 @@ AEEResult dspsignal_create(int domain, uint32_t id, uint32_t flags) {
   VERIFYC(flags == 0, AEE_EBADPARM);
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
   VERIFY((nErr = init_domain_signals(domain)) == 0);
-  VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
+  VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
   errno = 0;
   nErr = ioctl_signal_create(ds->dev, id, flags);
   if (nErr) {
@@ -167,7 +146,7 @@ AEEResult dspsignal_destroy(int domain, uint32_t id) {
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
+  VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
   errno = 0;
   nErr = ioctl_signal_destroy(ds->dev, id);
   if (nErr) {
@@ -192,7 +171,7 @@ AEEResult dspsignal_signal(int domain, uint32_t id) {
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
+  VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
 
   FARF(MEDIUM, "%s: Send signal %u", __func__, id);
   errno = 0;
@@ -218,7 +197,7 @@ AEEResult dspsignal_wait(int domain, uint32_t id, uint32_t timeout_usec) {
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
+  VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
   fastrpc_qos_activity(domain);
 
   FARF(MEDIUM, "%s: Wait signal %u timeout %u", __func__, id, timeout_usec);
@@ -253,7 +232,7 @@ AEEResult dspsignal_cancel_wait(int domain, uint32_t id) {
   VERIFYC(id < DSPSIGNAL_NUM_SIGNALS, AEE_EBADPARM);
   domain = get_domain(domain);
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  VERIFYC((ds = (struct dspsignal_domain_signals *)signals->domain_signals[domain]) != NULL, AEE_EBADSTATE);
+  VERIFY_DSPSIGNAL_NODE_PRESENT(domain);
 
   FARF(MEDIUM, "%s: Cancel wait signal %u", __func__, id);
   errno = 0;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -337,6 +337,10 @@ static int open_device_node(int domain_id);
 static int close_device_node(int domain_id, int dev);
 extern int apps_mem_table_init(void);
 extern void apps_mem_table_deinit(void);
+extern int log_config_table_init(void);
+extern void log_config_table_deinit(void);
+extern int dspqueue_info_table_init(void);
+extern void dspqueue_info_table_deinit(void);
 
 static uint32_t crc_table[256];
 uint32 timer_expired = 0;
@@ -4123,13 +4127,17 @@ static void fastrpc_apps_user_deinit(void) {
   }
   pthread_mutex_destroy(&dsp_client_mut);
 #endif
-  fastrpc_context_table_deinit();
-  deinit_process_signals();
+fastrpc_context_table_deinit();
+  fastrpc_dspsignal_deinit();
   fastrpc_notif_deinit();
   apps_mem_table_deinit();
   fastrpc_wake_lock_deinit();
   fastrpc_log_deinit();
   fastrpc_mem_deinit();
+  fastrpc_adspmsgd_deinit();
+  dspqueue_info_table_deinit();
+  fastrpc_async_deinit();
+  log_config_table_deinit();
   PL_DEINIT(apps_std);
   PL_DEINIT(rpcmem);
   PL_DEINIT(gpls);
@@ -4190,8 +4198,13 @@ static int fastrpc_apps_user_init(void) {
   VERIFY(AEE_SUCCESS == (nErr = PL_INIT(rpcmem)));
   fastrpc_mem_init();
   fastrpc_context_table_init();
+  dspqueue_info_table_init();
+  fastrpc_dspsignal_init();
   fastrpc_log_init();
+  fastrpc_adspmsgd_init();
   fastrpc_config_init();
+  fastrpc_async_init();
+  log_config_table_init();
   pthread_mutex_init(&update_notif_list_mut, 0);
 #ifndef NO_HAL
   pthread_mutex_init(&dsp_client_mut, 0);


### PR DESCRIPTION
As number of cores on each target increase, maintenance of domain-ID based arrays is not scalable. Hence domain ID based arrays need to be converted to hash tables which can support dynamic number of cores.