### PR TITLE
Resolving the buffer accessed out of bound issue.

### DIFF
--- a/inc/apps_std_internal.h
+++ b/inc/apps_std_internal.h
@@ -19,6 +19,8 @@
 #define ADSP_LIBRARY_PATH "ADSP_LIBRARY_PATH"
 #define DSP_LIBRARY_PATH "DSP_LIBRARY_PATH"
 #define ADSP_AVS_PATH "ADSP_AVS_CFG_PATH"
+#define MAX_NON_PRELOAD_LIBS_LEN 2048
+#define FILE_EXT ".so"
 
 // Locations where shell file can be found
 #ifndef ENABLE_UPSTREAM_DRIVER_INTERFACE


### PR DESCRIPTION
While packing shared buffer with names of all shared objects present in custom DSP_LIBRARY_PATH , their is a possibility of buffer overflow if the shared object names are exceeding the desired limit.The change makes sure the limit is not exceeded thus avoiding buffer overflow. Also, the buffer was allocated with 1KB memory which might fall short to accomodate all the needed shared object names so, increasing this size to 2KB.