### PR TITLE
Update GitHub workflow to use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/build_linux_gnu.yml
+++ b/.github/workflows/build_linux_gnu.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Git checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       # required for all workflows


### PR DESCRIPTION
Update GitHub workflow to use ubuntu-22.04 instead of ubuntu-latest

This change is made to avoid issues related to the ongoing Ubuntu upgrade in the CI workflow.