### PR TITLE
Resolve compilation failure

### DIFF
--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 /* Header file used by all other modules
  * will contain the most critical defines

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/syscall.h>
 
 #define FARF_ERROR 1
 #define FARF_HIGH 1
@@ -1340,7 +1341,7 @@ int remote_handle_invoke_domain(int domain, remote_handle handle,
       frpc_timer.sc = sc;
       frpc_timer.handle = handle;
       frpc_timer.timeout_millis = rpc_timeout;
-      frpc_timer.tid = gettid();
+      frpc_timer.tid = syscall(SYS_gettid);
       fastrpc_add_timer(&frpc_timer);
     }
   }


### PR DESCRIPTION
gettid() is causing implicit function declaration failure. Use syscall to get tid instead of gettid() call. Also add header to get definition of gettimeofday