### PR TITLE
Add new function remotectl_open_v2

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -535,7 +535,7 @@ remote_handle64 get_adsp_perf1_handle(int domain);
   * @returns: 0 on success, valid non-zero error code on failure
   *
   **/
-int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local, const char *name);
+int fastrpc_update_module_list(uint32_t req, int domain, remote_handle64 handle, remote_handle64 *local, const char *name, int fd);
 
 /**
   * @brief functions to wrap ioctl syscalls for downstream and upstream kernel

--- a/inc/fastrpc_mem.h
+++ b/inc/fastrpc_mem.h
@@ -56,3 +56,5 @@ int remote_mmap64_internal(int fd, uint32_t flags, uint64_t vaddrin, int64_t siz
 int fastrpc_buffer_ref(int domain, int fd, int ref, void **va, size_t *size);
 
 #endif //FASTRPC_MEM_H
+
+void* get_source_vaddr(int fd, int domain);

--- a/inc/mod_table.h
+++ b/inc/mod_table.h
@@ -105,6 +105,17 @@ int mod_table_register_const_handle(remote_handle handle, const char* in_name, i
  */
 int mod_table_register_const_handle1(remote_handle remote, remote_handle64 local, const char* uri, int (*pfn)(remote_handle64 h, uint32 sc, remote_arg* pra));
 
+struct parsed_uri {
+  const char *file;
+  const char *sym;
+  const char *ver;
+  int filelen;
+  int symlen;
+  int verlen;
+};
+
+int parse_uri(const char *uri, int urilen, struct parsed_uri *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/remotectl.h
+++ b/inc/remotectl.h
@@ -46,6 +46,7 @@ __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl_open)(const char* name, int* ha
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl_close)(int handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl_grow_heap)(uint32 phyAddr, uint32 nSize) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl_set_param)(int reqID, const uint32* params, int paramsLen) __QAIC_HEADER_ATTRIBUTE;
+__QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl_open_v2)(const char* name, const char* buf, int bufLen, int* handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_HEADER_ATTRIBUTE;
 #ifdef __cplusplus
 }
 #endif

--- a/inc/remotectl1.h
+++ b/inc/remotectl1.h
@@ -264,6 +264,7 @@ __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl1_open1)(remote_handle64 _h, con
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl1_close1)(remote_handle64 _h, int handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl1_grow_heap)(remote_handle64 _h, uint32 phyAddr, uint32 nSize) __QAIC_HEADER_ATTRIBUTE;
 __QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl1_set_param)(remote_handle64 _h, int reqID, const uint32* params, int paramsLen) __QAIC_HEADER_ATTRIBUTE;
+__QAIC_HEADER_EXPORT int __QAIC_HEADER(remotectl1_open1_v2)(remote_handle64 _h, const char* name, const char* buf, int bufLen, int* handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_HEADER_ATTRIBUTE;
 #ifndef remotectl1_URI
 #define remotectl1_URI "file:///libremotectl1_skel.so?remotectl1_skel_handle_invoke&_modver=1.0"
 #endif /*remotectl1_URI*/

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -440,6 +440,22 @@ int fdlist_fd_from_buf(void *buf, int bufLen, int *nova, void **base, int *attr,
   return 0;
 }
 
+void* get_source_vaddr(int fd, int domain) {
+  struct static_map *tNode = NULL;
+  QNode *pn, *pnn;
+  /* Search for mapping in current session static map list */
+  pthread_mutex_lock(&smaplst[domain].mut);
+  QLIST_NEXTSAFE_FOR_ALL(&smaplst[domain].ql, pn, pnn) {
+    tNode = STD_RECOVER_REC(struct static_map, qn, pn);
+    if (tNode->map.fd == fd) {
+      break;
+    }
+  }
+  pthread_mutex_unlock(&smaplst[domain].mut);
+  
+  return (void*)tNode->map.vaddrin;
+}
+
 int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
                  enum fastrpc_map_flags flags) {
   struct fastrpc_map map = {0};

--- a/src/fastrpc_perf.c
+++ b/src/fastrpc_perf.c
@@ -249,7 +249,7 @@ static int perf_dsp_enable(int domain) {
       FARF(ALWAYS,
            "Warning 0x%x: %s: adsp_perf1 domains not supported for domain %d\n",
            nErr, __func__, domain);
-      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_perf1_handle, NULL, NULL);
+      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_perf1_handle, NULL, NULL, -1);
       gperf.adsp_perf_handle = INVALID_HANDLE;
       VERIFY(0 == (nErr = adsp_perf_get_keys(keys, PERF_KEY_STR_MAX, &maxLen,
                                              &numKeys)));

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -59,7 +59,7 @@ __QAIC_IMPL(apps_remotectl_open)(const char *name, uint32 *handle, char *dlStr,
          (nErr = mod_table_open(name, handle, dlStr, dlerrorLen, dlErr)));
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local, NULL)));
+              REVERSE_HANDLE_LIST_PREPEND, domain, (remote_handle)*handle, &local, NULL, -1)));
 bail:
   return nErr;
 }
@@ -81,7 +81,7 @@ __QAIC_IMPL(apps_remotectl_close)(uint32 handle, char *errStr, int errStrLen,
   }
   VERIFY(AEE_SUCCESS ==
          (nErr = fastrpc_update_module_list(
-              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL, NULL)));
+              REVERSE_HANDLE_LIST_DEQUEUE, domain, (remote_handle)handle, NULL, NULL, -1)));
 bail:
   return nErr;
 }
@@ -350,7 +350,7 @@ static void *listener_start_thread(void *arg) {
         nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
       FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
            nErr, __func__);
-      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL);
+      fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL, -1);
       adsp_listener1_handle = INVALID_HANDLE;
       VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));
     } else if (nErr == AEE_SUCCESS) {

--- a/src/mod_table.c
+++ b/src/mod_table.c
@@ -123,14 +123,14 @@ struct const_mod {
   char uri[1];
 };
 
-struct parsed_uri {
-  const char *file;
-  const char *sym;
-  const char *ver;
-  int filelen;
-  int symlen;
-  int verlen;
-};
+// struct parsed_uri {
+//   const char *file;
+//   const char *sym;
+//   const char *ver;
+//   int filelen;
+//   int symlen;
+//   int verlen;
+// };
 
 struct open_mod {
   void *dlhandle;
@@ -359,7 +359,7 @@ static int notqmark(struct sbuf *buf) { return sbuf_notchar(buf, '?'); }
 static int notandoreq(struct sbuf *buf) { return sbuf_notchars(buf, "&="); }
 static int notand(struct sbuf *buf) { return sbuf_notchar(buf, '&'); }
 
-static int parse_uri(const char *uri, int urilen, struct parsed_uri *out) {
+int parse_uri(const char *uri, int urilen, struct parsed_uri *out) {
   // "file:///librhtest_skel.so?rhtest_skel_handle_invoke&_modver=1.0"
   int nErr = 0;
   char *name, *value;

--- a/src/remotectl1_stub.c
+++ b/src/remotectl1_stub.c
@@ -277,14 +277,14 @@ struct Interface {
 
 static const Type types[2];
 static const Type types[2] = {{0x1,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x1},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4}};
-static const Parameter parameters[8] = {{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)0x0,0}}, 4,SLIM_IFPTR32(0x4,0x8),0,0},{SLIM_IFPTR32(0x4,0x8),{{(const uintptr_t)0xdeadc0de,(const uintptr_t)0}}, 0,SLIM_IFPTR32(0x4,0x8),3,0},{SLIM_IFPTR32(0x4,0x8),{{(const uintptr_t)0xdeadc0de,(const uintptr_t)0}}, 0,SLIM_IFPTR32(0x4,0x8),0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,3,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),3,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[1]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0}};
-static const Parameter* const parameterArrays[14] = {(&(parameters[0])),(&(parameters[3])),(&(parameters[4])),(&(parameters[3])),(&(parameters[5])),(&(parameters[4])),(&(parameters[3])),(&(parameters[5])),(&(parameters[7])),(&(parameters[6])),(&(parameters[6])),(&(parameters[0])),(&(parameters[1])),(&(parameters[2]))};
-static const Method methods[6] = {{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x1),0x4,0x0,2,2,(&(parameterArrays[11])),0x4,0x1},{REMOTE_SCALARS_MAKEX(0,0,0x0,0x0,0x1,0x0),0x0,0x0,1,1,(&(parameterArrays[13])),0x1,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x2,0x0,0x0),0x8,0x8,6,4,(&(parameterArrays[0])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x2,0x0,0x0),0x8,0x4,5,3,(&(parameterArrays[4])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x0,0x0,0x0),0x8,0x0,2,2,(&(parameterArrays[9])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x0),0x8,0x0,3,2,(&(parameterArrays[7])),0x4,0x0}};
-static const Method* const methodArrays[6] = {&(methods[0]),&(methods[1]),&(methods[2]),&(methods[3]),&(methods[4]),&(methods[5])};
-static const char strings[103] = "set_param\0grow_heap\0phyAddr\0dlerror\0params\0close1\0handle\0reqID\0nSize\0open1\0close\0nErr\0name\0open\0uri\0h\0";
-static const uint16_t methodStrings[20] = {69,86,50,28,81,43,50,28,81,0,57,36,10,20,63,91,96,100,75,100};
-static const uint16_t methodStringsArrays[6] = {15,18,0,5,12,9};
-__QAIC_SLIM_EXPORT const Interface __QAIC_SLIM(remotectl1_slim) = {6,&(methodArrays[0]),0,0,&(methodStringsArrays [0]),methodStrings,strings};
+static const Parameter parameters[9] = {{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)0x0,0}}, 4,SLIM_IFPTR32(0x4,0x8),0,0},{SLIM_IFPTR32(0x4,0x8),{{(const uintptr_t)0xdeadc0de,(const uintptr_t)0}}, 0,SLIM_IFPTR32(0x4,0x8),3,0},{SLIM_IFPTR32(0x4,0x8),{{(const uintptr_t)0xdeadc0de,(const uintptr_t)0}}, 0,SLIM_IFPTR32(0x4,0x8),0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,3,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),3,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[1]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0}};
+static const Parameter* const parameterArrays[19] = {(&(parameters[0])),(&(parameters[8])),(&(parameters[3])),(&(parameters[4])),(&(parameters[3])),(&(parameters[0])),(&(parameters[3])),(&(parameters[4])),(&(parameters[3])),(&(parameters[5])),(&(parameters[4])),(&(parameters[3])),(&(parameters[5])),(&(parameters[7])),(&(parameters[6])),(&(parameters[6])),(&(parameters[0])),(&(parameters[1])),(&(parameters[2]))};
+static const Method methods[7] = {{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x1),0x4,0x0,2,2,(&(parameterArrays[16])),0x4,0x1},{REMOTE_SCALARS_MAKEX(0,0,0x0,0x0,0x1,0x0),0x0,0x0,1,1,(&(parameterArrays[18])),0x1,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x2,0x0,0x0),0x8,0x8,6,4,(&(parameterArrays[5])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x2,0x0,0x0),0x8,0x4,5,3,(&(parameterArrays[9])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x0,0x0,0x0),0x8,0x0,2,2,(&(parameterArrays[14])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x0),0x8,0x0,3,2,(&(parameterArrays[12])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x3,0x2,0x0,0x0),0xc,0x8,8,5,(&(parameterArrays[0])),0x4,0x4}};
+static const Method* const methodArrays[7] = {&(methods[0]),&(methods[1]),&(methods[2]),&(methods[3]),&(methods[4]),&(methods[5]),&(methods[6])};
+static const char strings[116] = "set_param\0grow_heap\0open1_v2\0phyAddr\0dlerror\0params\0close1\0handle\0reqID\0nSize\0open1\0close\0nErr\0name\0open\0buf\0uri\0h\0";
+static const uint16_t methodStrings[26] = {20,95,105,59,37,90,78,95,59,37,90,52,59,37,90,0,66,45,10,29,72,100,109,113,84,113};
+static const uint16_t methodStringsArrays[7] = {21,24,6,11,18,15,0};
+__QAIC_SLIM_EXPORT const Interface __QAIC_SLIM(remotectl1_slim) = {7,&(methodArrays[0]),0,0,&(methodStringsArrays [0]),methodStrings,strings};
 #endif //_REMOTECTL1_SLIM_H
 
 
@@ -401,6 +401,44 @@ static __inline int _stub_method_3(remote_handle64 _handle, uint32_t _mid, uint3
 __QAIC_STUB_EXPORT int __QAIC_STUB(remotectl1_set_param)(remote_handle64 _handle, int reqID, const uint32* params, int paramsLen) __QAIC_STUB_ATTRIBUTE {
    uint32_t _mid = 5;
    return _stub_method_3(_handle, _mid, (uint32_t*)&reqID, (char**)&params, (uint32_t*)&paramsLen);
+}
+static __inline int _stub_method_4(remote_handle64 _handle, uint32_t _mid, char* _in0[1], char* _in1[1], uint32_t _in1Len[1], uint32_t _rout2[1], char* _rout3[1], uint32_t _rout3Len[1], uint32_t _rout4[1]) {
+   uint32_t _in0Len[1] = {0};
+   int _numIn[1] = {0};
+   remote_arg _pra[5] = {0};
+   uint32_t _primIn[3]= {0};
+   uint32_t _primROut[2]= {0};
+   remote_arg* _praIn = 0;
+   remote_arg* _praROut = 0;
+   int _nErr = 0;
+   _numIn[0] = 2;
+   _pra[0].buf.pv = (void*)_primIn;
+   _pra[0].buf.nLen = sizeof(_primIn);
+   _pra[(_numIn[0] + 1)].buf.pv = (void*)_primROut;
+   _pra[(_numIn[0] + 1)].buf.nLen = sizeof(_primROut);
+   _in0Len[0] = (uint32_t)(1 + strlen(_in0[0]));
+   _COPY(_primIn, 0, _in0Len, 0, 4);
+   _praIn = (_pra + 1);
+   _praIn[0].buf.pv = (void*) _in0[0];
+   _praIn[0].buf.nLen = (1 * _in0Len[0]);
+   _COPY(_primIn, 4, _in1Len, 0, 4);
+   _praIn[1].buf.pv = (void*) _in1[0];
+   _praIn[1].buf.nLen = (1 * _in1Len[0]);
+   _COPY(_primIn, 8, _rout3Len, 0, 4);
+   _praROut = (_praIn + _numIn[0] + 1);
+   _praROut[0].buf.pv = _rout3[0];
+   _praROut[0].buf.nLen = (1 * _rout3Len[0]);
+   _TRY_FARF(_nErr, __QAIC_REMOTE(remote_handle64_invoke)(_handle, REMOTE_SCALARS_MAKEX(0, _mid, 3, 2, 0, 0), _pra));
+   _COPY(_rout2, 0, _primROut, 0, 4);
+   _COPY(_rout4, 0, _primROut, 4, 4);
+   _CATCH_FARF(_nErr) {
+      _QAIC_FARF(RUNTIME_ERROR, "ERROR 0x%x: handle=0x%"PRIx64", scalar=0x%x, method ID=%d: %s failed\n", _nErr , _handle, REMOTE_SCALARS_MAKEX(0, _mid, 3, 2, 0, 0), _mid, __func__);
+   }
+   return _nErr;
+}
+__QAIC_STUB_EXPORT int __QAIC_STUB(remotectl1_open1_v2)(remote_handle64 _handle, const char* name, const char* buf, int bufLen, int* handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_STUB_ATTRIBUTE {
+   uint32_t _mid = 6;
+   return _stub_method_4(_handle, _mid, (char**)&name, (char**)&buf, (uint32_t*)&bufLen, (uint32_t*)handle, (char**)&dlerror, (uint32_t*)&dlerrorLen, (uint32_t*)nErr);
 }
 #ifdef __cplusplus
 }

--- a/src/remotectl_stub.c
+++ b/src/remotectl_stub.c
@@ -436,14 +436,14 @@ struct Interface {
 
 static const Type types[2];
 static const Type types[2] = {{0x1,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x1},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4}};
-static const Parameter parameters[6] = {{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)0x0,0}}, 4,SLIM_IFPTR32(0x4,0x8),0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,3,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),3,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[1]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0}};
-static const Parameter* const parameterArrays[11] = {(&(parameters[0])),(&(parameters[1])),(&(parameters[2])),(&(parameters[1])),(&(parameters[3])),(&(parameters[2])),(&(parameters[1])),(&(parameters[3])),(&(parameters[5])),(&(parameters[4])),(&(parameters[4]))};
-static const Method methods[4] = {{REMOTE_SCALARS_MAKEX(0,0,0x2,0x2,0x0,0x0),0x8,0x8,6,4,(&(parameterArrays[0])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x2,0x0,0x0),0x8,0x4,5,3,(&(parameterArrays[4])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x0,0x0,0x0),0x8,0x0,2,2,(&(parameterArrays[9])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x0),0x8,0x0,3,2,(&(parameterArrays[7])),0x4,0x0}};
-static const Method* const methodArrays[4] = {&(methods[0]),&(methods[1]),&(methods[2]),&(methods[3])};
-static const char strings[84] = "set_param\0grow_heap\0phyAddr\0dlerror\0params\0handle\0reqID\0nSize\0close\0nErr\0name\0open\0";
-static const uint16_t methodStrings[15] = {78,73,43,28,68,62,43,28,68,0,50,36,10,20,56};
-static const uint16_t methodStringsArrays[4] = {0,5,12,9};
-__QAIC_SLIM_EXPORT const Interface __QAIC_SLIM(remotectl_slim) = {4,&(methodArrays[0]),0,0,&(methodStringsArrays [0]),methodStrings,strings};
+static const Parameter parameters[7] = {{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)0x0,0}}, 4,SLIM_IFPTR32(0x4,0x8),0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,3,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),3,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{0x4,{{(const uintptr_t)0,(const uintptr_t)1}}, 2,0x4,0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[1]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0},{SLIM_IFPTR32(0x8,0x10),{{(const uintptr_t)&(types[0]),(const uintptr_t)0x0}}, 9,SLIM_IFPTR32(0x4,0x8),0,0}};
+static const Parameter* const parameterArrays[16] = {(&(parameters[0])),(&(parameters[6])),(&(parameters[1])),(&(parameters[2])),(&(parameters[1])),(&(parameters[0])),(&(parameters[1])),(&(parameters[2])),(&(parameters[1])),(&(parameters[3])),(&(parameters[2])),(&(parameters[1])),(&(parameters[3])),(&(parameters[5])),(&(parameters[4])),(&(parameters[4]))};
+static const Method methods[5] = {{REMOTE_SCALARS_MAKEX(0,0,0x2,0x2,0x0,0x0),0x8,0x8,6,4,(&(parameterArrays[5])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x2,0x0,0x0),0x8,0x4,5,3,(&(parameterArrays[9])),0x4,0x4},{REMOTE_SCALARS_MAKEX(0,0,0x1,0x0,0x0,0x0),0x8,0x0,2,2,(&(parameterArrays[14])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x2,0x0,0x0,0x0),0x8,0x0,3,2,(&(parameterArrays[12])),0x4,0x0},{REMOTE_SCALARS_MAKEX(0,0,0x3,0x2,0x0,0x0),0xc,0x8,8,5,(&(parameterArrays[0])),0x4,0x4}};
+static const Method* const methodArrays[5] = {&(methods[0]),&(methods[1]),&(methods[2]),&(methods[3]),&(methods[4])};
+static const char strings[96] = "set_param\0grow_heap\0open_v2\0phyAddr\0dlerror\0params\0handle\0reqID\0nSize\0close\0nErr\0name\0open\0buf\0";
+static const uint16_t methodStrings[21] = {20,81,91,51,36,76,86,81,51,36,76,70,51,36,76,0,58,44,10,28,64};
+static const uint16_t methodStringsArrays[5] = {6,11,18,15,0};
+__QAIC_SLIM_EXPORT const Interface __QAIC_SLIM(remotectl_slim) = {5,&(methodArrays[0]),0,0,&(methodStringsArrays [0]),methodStrings,strings};
 #endif //_REMOTECTL_SLIM_H
 #ifdef __cplusplus
 extern "C" {
@@ -667,6 +667,48 @@ __QAIC_STUB_EXPORT int __QAIC_STUB(remotectl_set_param)(int reqID, const uint32*
    {
        return AEE_EINVHANDLE;
    }
+}
+static __inline int _stub_method_4(remote_handle _handle, uint32_t _mid, char* _in0[1], char* _in1[1], uint32_t _in1Len[1], uint32_t _rout2[1], char* _rout3[1], uint32_t _rout3Len[1], uint32_t _rout4[1]) {
+   uint32_t _in0Len[1] = {0};
+   int _numIn[1] = {0};
+   remote_arg _pra[5] = {0};
+   uint32_t _primIn[3]= {0};
+   uint32_t _primROut[2]= {0};
+   remote_arg* _praIn = 0;
+   remote_arg* _praROut = 0;
+   int _nErr = 0;
+   _numIn[0] = 2;
+   _pra[0].buf.pv = (void*)_primIn;
+   _pra[0].buf.nLen = sizeof(_primIn);
+   _pra[(_numIn[0] + 1)].buf.pv = (void*)_primROut;
+   _pra[(_numIn[0] + 1)].buf.nLen = sizeof(_primROut);
+   _in0Len[0] = (uint32_t)(1 + strlen(_in0[0]));
+   _COPY(_primIn, 0, _in0Len, 0, 4);
+   _praIn = (_pra + 1);
+   _praIn[0].buf.pv = (void*) _in0[0];
+   _praIn[0].buf.nLen = (1 * _in0Len[0]);
+   _COPY(_primIn, 4, _in1Len, 0, 4);
+   _praIn[1].buf.pv = (void*) _in1[0];
+   _praIn[1].buf.nLen = (1 * _in1Len[0]);
+   _COPY(_primIn, 8, _rout3Len, 0, 4);
+   _praROut = (_praIn + _numIn[0] + 1);
+   _praROut[0].buf.pv = _rout3[0];
+   _praROut[0].buf.nLen = (1 * _rout3Len[0]);
+   _TRY(_nErr, __QAIC_REMOTE(remote_handle_invoke)(_handle, REMOTE_SCALARS_MAKEX(0, _mid, 3, 2, 0, 0), _pra));
+   _COPY(_rout2, 0, _primROut, 0, 4);
+   _COPY(_rout4, 0, _primROut, 4, 4);
+   _CATCH(_nErr) {}
+   return _nErr;
+}
+__QAIC_STUB_EXPORT int __QAIC_STUB(remotectl_open_v2)(const char* name, const char* buf, int bufLen, int* handle, char* dlerror, int dlerrorLen, int* nErr) __QAIC_STUB_ATTRIBUTE {
+   uint32_t _mid = 4;
+   remote_handle _handle = _remotectl_handle();
+   if (_handle != (remote_handle)-1){
+      return _stub_method_4(_handle, _mid, (char**)&name, (char**)&buf, (uint32_t*)&bufLen, (uint32_t*)handle, (char**)&dlerror, (uint32_t*)&dlerrorLen, (uint32_t*)nErr);
+   }
+   else {
+       return AEE_EINVHANDLE;
+    }
 }
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit introduces a new function, remotectl_open_v2, which includes additional arguments buf and bufLen. Previously, the dlopen_ex function executed with buf and bufLen set to zero on the DSP side. With this update, the virtual address and file length are now sourced from the userspace side.