### PR TITLE
Add changes to support GPDSPs offloading

### DIFF
--- a/inc/fastrpc_ioctl.h
+++ b/inc/fastrpc_ioctl.h
@@ -31,11 +31,15 @@
 #define MDSPRPC_DEVICE "/dev/fastrpc-mdsp"
 #define CDSPRPC_DEVICE "/dev/fastrpc-cdsp"
 #define CDSP1RPC_DEVICE "/dev/fastrpc-cdsp1"
+#define GDSP0RPC_DEVICE "/dev/fastrpc-gdsp0"
+#define GDSP1RPC_DEVICE "/dev/fastrpc-gdsp1"
 #define ADSPRPC_SECURE_DEVICE "/dev/fastrpc-adsp-secure"
 #define SDSPRPC_SECURE_DEVICE "/dev/fastrpc-sdsp-secure"
 #define MDSPRPC_SECURE_DEVICE "/dev/fastrpc-mdsp-secure"
 #define CDSPRPC_SECURE_DEVICE "/dev/fastrpc-cdsp-secure"
 #define CDSP1RPC_SECURE_DEVICE "/dev/fastrpc-cdsp1-secure"
+#define GDSP0RPC_SECURE_DEVICE "/dev/fastrpc-gdsp0-secure"
+#define GDSP1RPC_SECURE_DEVICE "/dev/fastrpc-gdsp1-secure"
 
 #define FASTRPC_ATTR_NOVA (256)
 

--- a/inc/remote.h
+++ b/inc/remote.h
@@ -122,6 +122,8 @@ extern "C" {
 #define SDSP_DOMAIN_ID    2
 #define CDSP_DOMAIN_ID    3
 #define CDSP1_DOMAIN_ID   4
+#define GDSP0_DOMAIN_ID   5
+#define GDSP1_DOMAIN_ID   6
 
 /** Supported Domain Names */
 #define ADSP_DOMAIN_NAME "adsp"
@@ -129,6 +131,8 @@ extern "C" {
 #define SDSP_DOMAIN_NAME "sdsp"
 #define CDSP_DOMAIN_NAME "cdsp"
 #define CDSP1_DOMAIN_NAME "cdsp1"
+#define GDSP0_DOMAIN_NAME "gdsp0"
+#define GDSP1_DOMAIN_NAME "gdsp1"
 
 /** Defines to prepare URI for multi-domain calls */
 #define ADSP_DOMAIN "&_dom=adsp"
@@ -136,6 +140,8 @@ extern "C" {
 #define SDSP_DOMAIN "&_dom=sdsp"
 #define CDSP_DOMAIN "&_dom=cdsp"
 #define CDSP1_DOMAIN "&_dom=cdsp1"
+#define GDSP0_DOMAIN "&_dom=gdsp0"
+#define GDSP1_DOMAIN "&_dom=gdsp1"
 
 /** Internal transport prefix */
 #define ITRANSPORT_PREFIX "'\":;./\\"

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -38,13 +38,17 @@
 #define MDSP_SECURE_DEVICE_NAME "fastrpc-mdsp-secure"
 #define CDSP_SECURE_DEVICE_NAME "fastrpc-cdsp-secure"
 #define CDSP1_SECURE_DEVICE_NAME "fastrpc-cdsp1-secure"
+#define GDSP0_SECURE_DEVICE_NAME "fastrpc-gdsp0-secure"
+#define GDSP1_SECURE_DEVICE_NAME "fastrpc-gdsp1-secure"
 
 // Array of supported domain names and its corresponding ID's.
 static domain_t supported_domains[] = {{ADSP_DOMAIN_ID, ADSP_DOMAIN},
                                        {MDSP_DOMAIN_ID, MDSP_DOMAIN},
                                        {SDSP_DOMAIN_ID, SDSP_DOMAIN},
                                        {CDSP_DOMAIN_ID, CDSP_DOMAIN},
-                                       {CDSP1_DOMAIN_ID, CDSP1_DOMAIN}};
+                                       {CDSP1_DOMAIN_ID, CDSP1_DOMAIN},
+                                       {GDSP0_DOMAIN_ID, GDSP0_DOMAIN},
+                                       {GDSP1_DOMAIN_ID, GDSP1_DOMAIN}};
 
 // Get domain name for the domain id.
 static domain_t *get_domain_uri(int domain_id) {
@@ -78,6 +82,12 @@ static const char *get_secure_device_name(int domain_id) {
 		break;
 	case CDSP1_DOMAIN_ID:
 		name = CDSP1_SECURE_DEVICE_NAME;
+		break;
+	case GDSP0_DOMAIN_ID:
+		name = GDSP0_SECURE_DEVICE_NAME;
+		break;
+	case GDSP1_DOMAIN_ID:
+		name = GDSP1_SECURE_DEVICE_NAME;
 		break;
 	default:
 		name = DEFAULT_DEVICE;

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -134,7 +134,7 @@ static void check_multilib_util(void);
 
 /* Array to store fastrpc library names. */
 static const char *fastrpc_library[NUM_DOMAINS] = {
-    "libadsprpc.so", "libmdsprpc.so", "libsdsprpc.so", "libcdsprpc.so", "libcdsprpc.so"};
+    "libadsprpc.so", "libmdsprpc.so", "libsdsprpc.so", "libcdsprpc.so", "libcdsprpc.so", "libcdsprpc.so", "libcdsprpc.so"};
 
 /* Array to store env variable names. */
 static char *fastrpc_dsp_lib_refcnt[NUM_DOMAINS];
@@ -262,7 +262,7 @@ const char *ANDROID_DEBUG_VAR_NAME[] = {"fastrpc.process.attrs",
                                         "persist.fastrpc.process.attrs",
                                         "ro.build.type"};
 
-const char *SUBSYSTEM_NAME[] = {"adsp", "mdsp", "sdsp", "cdsp", "cdsp1", "reserved", "reserved", "reserved"};
+const char *SUBSYSTEM_NAME[] = {"adsp", "mdsp", "sdsp", "cdsp", "cdsp1", "gdsp0", "gdsp1", "reserved"};
 
 /* Strings for trace event logging */
 #define INVOKE_BEGIN_TRACE_STR "fastrpc_msg: userspace_call: begin"
@@ -776,6 +776,12 @@ static int get_domain_from_domain_name(const char *domain_name,
     } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[CDSP_DOMAIN_ID],
                             std_strlen(SUBSYSTEM_NAME[CDSP_DOMAIN_ID]))) {
       domain = CDSP_DOMAIN_ID;
+    } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[GDSP0_DOMAIN_ID],
+                            std_strlen(SUBSYSTEM_NAME[GDSP0_DOMAIN_ID]))) {
+      domain = GDSP0_DOMAIN_ID;
+    } else if (!std_strncmp(domain_name, SUBSYSTEM_NAME[GDSP1_DOMAIN_ID],
+                            std_strlen(SUBSYSTEM_NAME[GDSP1_DOMAIN_ID]))) {
+      domain = GDSP1_DOMAIN_ID;
     } else {
       FARF(ERROR, "ERROR: %s Invalid domain name: %s\n", __func__, domain_name);
     }
@@ -802,6 +808,12 @@ static const char *get_domain_from_id(int domain_id) {
     break;
   case SDSP_DOMAIN_ID:
     uri_domain_suffix = SDSP_DOMAIN;
+    break;
+  case GDSP0_DOMAIN_ID:
+    uri_domain_suffix = GDSP0_DOMAIN;
+    break;
+  case GDSP1_DOMAIN_ID:
+    uri_domain_suffix = GDSP1_DOMAIN;
     break;
   default:
     uri_domain_suffix = "invalid domain";
@@ -3049,6 +3061,12 @@ int get_domain_from_name(const char *uri, uint32_t type) {
     } else if (!std_strncmp(uri, CDSP_DOMAIN_NAME,
                             std_strlen(CDSP_DOMAIN_NAME))) {
       domain = CDSP_DOMAIN_ID;
+    } else if (!std_strncmp(uri, GDSP0_DOMAIN_NAME,
+                            std_strlen(GDSP0_DOMAIN_NAME))) {
+      domain = GDSP0_DOMAIN_ID;
+    } else if (!std_strncmp(uri, GDSP1_DOMAIN_NAME,
+                            std_strlen(GDSP1_DOMAIN_NAME))) {
+      domain = GDSP1_DOMAIN_ID;
     } else {
       domain = INVALID_DOMAIN_ID;
       FARF(ERROR, "Invalid domain name: %s\n", uri);
@@ -3066,6 +3084,10 @@ int get_domain_from_name(const char *uri, uint32_t type) {
       domain = CDSP1_DOMAIN_ID;
     } else if (std_strstr(uri, CDSP_DOMAIN)) {
       domain = CDSP_DOMAIN_ID;
+    } else if (std_strstr(uri, GDSP0_DOMAIN)) {
+      domain = GDSP0_DOMAIN_ID;
+    } else if (std_strstr(uri, GDSP1_DOMAIN)) {
+      domain = GDSP1_DOMAIN_ID;
     } else {
       domain = INVALID_DOMAIN_ID;
       FARF(ERROR, "Invalid domain name: %s\n", uri);
@@ -3155,6 +3177,8 @@ static int attach_guestos(int domain) {
   case CDSP_DOMAIN_ID:
   case SDSP_DOMAIN_ID:
   case CDSP1_DOMAIN_ID:
+  case GDSP0_DOMAIN_ID:
+  case GDSP1_DOMAIN_ID:
     attach = USERPD;
     break;
   default:
@@ -3260,6 +3284,12 @@ static const char *get_domain_name(int domain_id) {
   case CDSP1_DOMAIN_ID:
     name = CDSP1RPC_DEVICE;
     break;
+  case GDSP0_DOMAIN_ID:
+    name = GDSP0RPC_DEVICE;
+    break;
+  case GDSP1_DOMAIN_ID:
+    name = GDSP1RPC_DEVICE;
+    break;
   default:
     name = DEFAULT_DEVICE;
     break;
@@ -3323,6 +3353,8 @@ static int open_device_node(int domain_id) {
     break;
   case CDSP_DOMAIN_ID:
   case CDSP1_DOMAIN_ID:
+  case GDSP0_DOMAIN_ID:
+  case GDSP1_DOMAIN_ID:
     dev = open(get_secure_domain_name(domain), O_NONBLOCK);
     if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
       FARF(RUNTIME_RPC_HIGH,
@@ -3376,8 +3408,8 @@ static int close_device_node(int domain_id, int dev) {
 
 #ifndef NO_HAL
   int sess_id = GET_SESSION_ID_FROM_DOMAIN_ID(domain_id);
-  if ((domain == CDSP_DOMAIN_ID) ||
-   (domain == CDSP1_DOMAIN_ID)) &&
+  if ((domain == CDSP_DOMAIN_ID) || (domain == CDSP1_DOMAIN_ID) ||
+   (domain == GDSP0_DOMAIN_ID) || (domain == GDSP1_DOMAIN_ID)) &&
    dsp_client_instance[sess_id]) {
     nErr = close_hal_session(dsp_client_instance[sess_id], domain_id, dev);
     FARF(ALWAYS, "%s: close device %d thru HAL on session %d\n", __func__, dev,
@@ -3574,7 +3606,8 @@ static int fastrpc_enable_kernel_optimizations(int domain) {
       dom = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain);
   const uint32_t max_concurrency = 25;
 
-  if (((dom != CDSP_DOMAIN_ID) && (dom != CDSP1_DOMAIN_ID)) || (hlist[domain].dsppd != USERPD))
+  if (((dom != CDSP_DOMAIN_ID) && (dom != CDSP1_DOMAIN_ID) &&
+    (dom != GDSP0_DOMAIN_ID) && (dom != GDSP1_DOMAIN_ID)) || (hlist[domain].dsppd != USERPD))
     goto bail;
   errno = 0;
 
@@ -4027,7 +4060,7 @@ static int domain_init(int domain, int *dev) {
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_mem_open(domain)));
   VERIFY(AEE_SUCCESS == (nErr = apps_mem_init(domain)));
 
-  if (dom == CDSP_DOMAIN_ID || dom == CDSP1_DOMAIN_ID) {
+  if (dom == CDSP_DOMAIN_ID || dom == CDSP1_DOMAIN_ID || dom == GDSP0_DOMAIN_ID || dom == GDSP1_DOMAIN_ID) {
     panic_handle = get_adsp_current_process1_handle(domain);
     if (panic_handle != INVALID_HANDLE) {
       int ret = -1;
@@ -4347,7 +4380,7 @@ __CONSTRUCTOR_ATTRIBUTE__
 static void multidsplib_env_init(void) {
   const char *local_fastrpc_lib_refcnt[NUM_DOMAINS] = {
       "FASTRPC_ADSP_REFCNT", "FASTRPC_MDSP_REFCNT", "FASTRPC_SDSP_REFCNT",
-      "FASTRPC_CDSP_REFCNT", "FASTRPC_CDSP1_REFCNT"};
+      "FASTRPC_CDSP_REFCNT", "FASTRPC_CDSP1_REFCNT", "FASTRPC_GDSP0_REFCNT", "FASTRPC_GDSP1_REFCNT"};
   char buf[64] = {0};
   size_t env_name_len = 0;
   char *env_name = NULL;

--- a/src/fastrpc_cap.c
+++ b/src/fastrpc_cap.c
@@ -21,13 +21,13 @@
 
 #define BUF_SIZE 50
 
-const char * RPROC_SUBSYSTEM_NAME[] = {"adsp", "mss", "spss", "cdsp", "cdsp1", "reserved", "reserved", "reserved"};
+const char * RPROC_SUBSYSTEM_NAME[] = {"adsp", "mss", "spss", "cdsp", "cdsp1", "gdsp0", "gdsp1", "reserved"};
 
 static inline uint32_t fastrpc_check_if_dsp_present_pil(uint32_t domain) {
 	uint32_t domain_supported = 0;
 	struct stat sb;
 	// mark rest of the list as reserved to avoid out of bound access
-	const char *SUBSYSTEM_DEV_NAME[] = {"/dev/subsys_adsp", "", "/dev/subsys_slpi", "/dev/subsys_cdsp", "/dev/subsys_cdsp1", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved"};
+	const char *SUBSYSTEM_DEV_NAME[] = {"/dev/subsys_adsp", "", "/dev/subsys_slpi", "/dev/subsys_cdsp", "/dev/subsys_cdsp1", "/dev/subsys_gdsp0", "/dev/subsys_gdsp1", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved", "reserved"};
 
 	// If device file is present, then target supports that DSP
 	if (!stat(SUBSYSTEM_DEV_NAME[domain], &sb)) {

--- a/src/fastrpc_ioctl.c
+++ b/src/fastrpc_ioctl.c
@@ -40,6 +40,12 @@ const char *get_secure_domain_name(int domain_id) {
   case CDSP1_DOMAIN_ID:
     name = CDSP1RPC_SECURE_DEVICE;
     break;
+  case GDSP0_DOMAIN_ID:
+    name = GDSP0RPC_SECURE_DEVICE;
+    break;
+  case GDSP1_DOMAIN_ID:
+    name = GDSP1RPC_SECURE_DEVICE;
+    break;
   default:
     name = DEFAULT_DEVICE;
     break;

--- a/src/gdsprpcd.c
+++ b/src/gdsprpcd.c
@@ -1,0 +1,68 @@
+// Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef VERIFY_PRINT_ERROR
+#define VERIFY_PRINT_ERROR
+#endif
+#define VERIFY_PRINT_INFO 0
+
+#include "AEEStdErr.h"
+#include "HAP_farf.h"
+#include "verify.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#ifndef GDSP_DEFAULT_LISTENER_NAME
+#define GDSP_DEFAULT_LISTENER_NAME "libcdsp_default_listener.so"
+#endif
+#ifndef GDSP_LIBHIDL_NAME
+#define GDSP_LIBHIDL_NAME "libhidlbase.so"
+#endif
+
+typedef int (*adsp_default_listener_start_t)(int argc, char *argv[]);
+
+int main(int argc, char *argv[]) {
+
+  int nErr = 0;
+  void *gdsphandler = NULL;
+#ifndef NO_HAL
+  void *libhidlbaseHandler = NULL;
+#endif
+  adsp_default_listener_start_t listener_start;
+
+  VERIFY_EPRINTF("gdsp daemon starting");
+#ifndef NO_HAL
+  if (NULL != (libhidlbaseHandler = dlopen(GDSP_LIBHIDL_NAME, RTLD_NOW))) {
+#endif
+    while (1) {
+      if (NULL !=
+          (gdsphandler = dlopen(GDSP_DEFAULT_LISTENER_NAME, RTLD_NOW))) {
+        if (NULL != (listener_start = (adsp_default_listener_start_t)dlsym(
+                         gdsphandler, "adsp_default_listener_start"))) {
+          VERIFY_IPRINTF("gdsp_default_listener_start called");
+          nErr = listener_start(argc, argv);
+        }
+        if (0 != dlclose(gdsphandler)) {
+          VERIFY_EPRINTF("dlclose failed");
+        }
+      } else {
+        VERIFY_EPRINTF("gdsp daemon error %s", dlerror());
+      }
+      if (nErr == AEE_ECONNREFUSED) {
+        VERIFY_EPRINTF("fastRPC device driver is disabled, daemon exiting...");
+        break;
+      }
+      VERIFY_EPRINTF("gdsp daemon will restart after 100ms...");
+      usleep(100000);
+    }
+#ifndef NO_HAL
+    if (0 != dlclose(libhidlbaseHandler)) {
+      VERIFY_EPRINTF("libhidlbase dlclose failed");
+    }
+  }
+#endif
+  VERIFY_EPRINTF("gdsp daemon exiting %x", nErr);
+
+  return nErr;
+}


### PR DESCRIPTION
FastRPC library supports 5 domains. There are some products where new domains, GPDSP0 and GPDSP1, are supported. Add changes to support GPDSPs domain.