### PR TITLE
Resolve compilation issues

### DIFF
--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>
+#include <sys/time.h>
 
 /* Header file used by all other modules
  * will contain the most critical defines

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -7,7 +7,7 @@
 //#ifndef VERIFY_PRINT_INFO
 //#define VERIFY_PRINT_INFO
 //#endif // VERIFY_PRINT_INFO
-
+#define _GNU_SOURCE
 #ifndef VERIFY_PRINT_WARN
 #define VERIFY_PRINT_WARN
 #endif // VERIFY_PRINT_WARN

--- a/src/fastrpc_log.c
+++ b/src/fastrpc_log.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#define _GNU_SOURCE
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -8,6 +9,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include "AEEStdErr.h"
 #include "fastrpc_config.h"


### PR DESCRIPTION
This change contains _GNU_SOURCE definition to enable gettid function usage. 
Also added sys/time.h header to enable time retrieval functions.