### PR TITLE
Remove fallback to default device open

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3279,14 +3279,10 @@ static const char *get_domain_name(int domain_id) {
  For ADSP, SDSP, MDSP domains:
    Open secure device node fist
      if no secure device, open actual device node
-     if still no device, open default node
-     if failed to open the secure node due to permission,
-     open default node
  For CDSP domain:
    Open secure device node fist
     If the node does not exist or if no permission, open actual device node
-    If still no device, open default node
-    If no permission to access the default node, access thorugh HAL.
+    If no permission to access the device node, access thorugh HAL.
 */
 static int open_device_node(int domain_id) {
   int dev = -1, nErr = 0;
@@ -3307,20 +3303,9 @@ static int open_device_node(int domain_id) {
       dev = open(get_domain_name(domain), O_NONBLOCK);
       if ((dev < 0) && (errno == ENOENT)) {
         FARF(RUNTIME_RPC_HIGH,
-             "Device node %s open failed for domain %d (errno %s),"
-             "falling back to node %s \n",
-             get_domain_name(domain), domain, strerror(errno), DEFAULT_DEVICE);
-        dev = open(DEFAULT_DEVICE, O_NONBLOCK);
+             "Device node %s open failed for domain %d (errno %s)\n",
+             get_domain_name(domain), domain, strerror(errno));
       }
-    } else if ((dev < 0) && (errno == EACCES)) {
-      // Open the default device node if unable to open the
-      // secure device node due to permissions
-      FARF(RUNTIME_RPC_HIGH,
-           "Device node %s open failed for domain %d (errno %s),"
-           "falling back to node %s \n",
-           get_secure_domain_name(domain), domain, strerror(errno),
-           DEFAULT_DEVICE);
-      dev = open(DEFAULT_DEVICE, O_NONBLOCK);
     }
     break;
   case CDSP_DOMAIN_ID:
@@ -3334,27 +3319,21 @@ static int open_device_node(int domain_id) {
            get_domain_name(domain));
       dev = open(get_domain_name(domain), O_NONBLOCK);
       if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
-        // Open the default device node if actual device node
-        // is not present
         FARF(RUNTIME_RPC_HIGH,
-             "Device node %s open failed for domain %d (errno %s),"
-             "falling back to node %s \n",
-             get_domain_name(domain), domain, strerror(errno), DEFAULT_DEVICE);
-        dev = open(DEFAULT_DEVICE, O_NONBLOCK);
+             "Device node %s open failed for domain %d (errno %s)\n",
+             get_domain_name(domain), domain, strerror(errno));
 #ifndef NO_HAL
-        if ((dev < 0) && (errno == EACCES)) {
-          FARF(ALWAYS,
-               "%s: no access to default device of domain %d, open thru HAL, "
-               "(sess_id %d)\n",
-               __func__, domain, sess_id);
-          VERIFYC(sess_id < NUM_SESSIONS, AEE_EBADITEM);
-          pthread_mutex_lock(&dsp_client_mut);
-          if (!dsp_client_instance[sess_id]) {
-            dsp_client_instance[sess_id] = create_dsp_client_instance();
-          }
-          pthread_mutex_unlock(&dsp_client_mut);
-          dev = open_hal_session(dsp_client_instance[sess_id], domain_id);
+        FARF(ALWAYS,
+             "%s: no access to device of domain %d, open thru HAL, "
+             "(sess_id %d)\n",
+             __func__, domain, sess_id);
+        VERIFYC(sess_id < NUM_SESSIONS, AEE_EBADITEM);
+        pthread_mutex_lock(&dsp_client_mut);
+        if (!dsp_client_instance[sess_id]) {
+          dsp_client_instance[sess_id] = create_dsp_client_instance();
         }
+        pthread_mutex_unlock(&dsp_client_mut);
+        dev = open_hal_session(dsp_client_instance[sess_id], domain_id);
 #endif
       }
     }


### PR DESCRIPTION
In case of default domain ID, the device open request falls back to DEFAUL_DEVICE which will be defined in the libs to which the application is linked. Remove this legacy fallback logic to avoid any confusion and unexpected observations.