### PR TITLE
rpcmem: Register rpcmem-allocated buffers with fastrpc memory framework

### DIFF
--- a/inc/fastrpc_mem.h
+++ b/inc/fastrpc_mem.h
@@ -55,4 +55,22 @@ int remote_mmap64_internal(int fd, uint32_t flags, uint64_t vaddrin, int64_t siz
 */
 int fastrpc_buffer_ref(int domain, int fd, int ref, void **va, size_t *size);
 
+
+/*
+ * Register or deregister a buffer with fastrpc framework, managing its reference count
+ * and associated metadata.
+ *
+ * @param buf Pointer to the buffer to be registered or deregistered
+ * @param size Size of the buffer in bytes
+ * @param fd File descriptor associated with the buffer; use -1 to deregister
+
+ * This function internally calls `remote_register_buf_common` with default attributes.
+ * - If `fd` is not -1, the buffer is registered and its reference count is incremented.
+ * - If `fd` is -1, the buffer is deregistered and its reference count is decremented.
+ *   If the reference count reaches zero, the buffer is unmapped and its metadata is freed.
+ *
+ * @return void
+ */
+void remote_register_buf(void *buf, int size, int fd);
+
 #endif //FASTRPC_MEM_H

--- a/src/rpcmem_linux.c
+++ b/src/rpcmem_linux.c
@@ -50,6 +50,7 @@
 #include "fastrpc_ioctl.h"
 #include "rpcmem.h"
 #include "verify.h"
+#include "fastrpc_mem.h"
 
 #define PAGE_SIZE 4096
 
@@ -202,6 +203,7 @@ void *rpcmem_alloc_internal(int heapid, uint32_t flags, size_t size) {
   pthread_mutex_unlock(&rpcmt);
   FARF(RUNTIME_RPC_HIGH, "Allocted memory from DMA heap fd %d ptr %p orig ptr %p\n",
        rinfo->fd, rinfo->aligned_buf, rinfo->buf);
+  remote_register_buf(rinfo->buf, rinfo->size, rinfo->fd);
   return rinfo->aligned_buf;
 bail:
   if (nErr) {
@@ -230,6 +232,7 @@ void rpcmem_free_internal(void *po) {
   }
   pthread_mutex_unlock(&rpcmt);
   if (rfree) {
+    remote_register_buf(rfree->buf, rfree->size, -1);
     munmap(rfree->buf, rfree->size);
     close(rfree->fd);
     free(rfree);


### PR DESCRIPTION
Currently, rpcmem-allocated buffers used in remote calls are not recognized by the RPC kernel driver, resulting in fallback to copy buffers for message passing. This fallback introduces significant performance degradation, which worsens with increasing buffer sizes.

This commit ensures that rpcmem-allocated buffers are properly registered with the fastrpc memory framework upon allocation and deregistered upon release. By enabling the kernel driver to identify the associated file descriptors, it avoids the use of copy buffers during remote invocation, thereby improving performance and efficiency.