### PR TITLE
inc: drop AEEStdDef.h from rpcmem.h to fix build

### DIFF
--- a/inc/rpcmem.h
+++ b/inc/rpcmem.h
@@ -4,7 +4,6 @@
 #ifndef RPCMEM_H
 #define RPCMEM_H
 
-#include "AEEStdDef.h"
 #include "stddef.h"
 
 /**


### PR DESCRIPTION
Fix the build failure for client where the vendor header fastrpc/rpcmem.h unconditionally includes AEEStdDef.h, which is not exported by fastrpc project.

.../usr/include/fastrpc/rpcmem.h:7:10: fatal error: AEEStdDef.h: No such file or directory
    7 | #include "AEEStdDef.h"
      |          ^~~~~~~~~~~~~
compilation terminated.