### PR TITLE
dsprpcd: dlopen versioned listener libraries with fallback

### DIFF
--- a/src/dsprpcd.c
+++ b/src/dsprpcd.c
@@ -15,39 +15,80 @@
 #include <unistd.h>
 #include <string.h>
 
-#ifndef ADSP_DEFAULT_LISTENER_NAME
-#define ADSP_DEFAULT_LISTENER_NAME "libadsp_default_listener.so"
+#ifndef ADSP_LISTENER_VERSIONED
+#define ADSP_LISTENER_VERSIONED   "libadsp_default_listener.so.1"
+#define ADSP_LISTENER_UNVERSIONED "libadsp_default_listener.so"
 #endif
-#ifndef CDSP_DEFAULT_LISTENER_NAME
-#define CDSP_DEFAULT_LISTENER_NAME "libcdsp_default_listener.so"
+#ifndef CDSP_LISTENER_VERSIONED
+#define CDSP_LISTENER_VERSIONED   "libcdsp_default_listener.so.1"
+#define CDSP_LISTENER_UNVERSIONED "libcdsp_default_listener.so"
 #endif
-#ifndef SDSP_DEFAULT_LISTENER_NAME
-#define SDSP_DEFAULT_LISTENER_NAME "libsdsp_default_listener.so"
+#ifndef SDSP_LISTENER_VERSIONED
+#define SDSP_LISTENER_VERSIONED   "libsdsp_default_listener.so.1"
+#define SDSP_LISTENER_UNVERSIONED "libsdsp_default_listener.so"
 #endif
-#ifndef GDSP_DEFAULT_LISTENER_NAME
-#define GDSP_DEFAULT_LISTENER_NAME "libcdsp_default_listener.so.1"
+#ifndef GDSP_LISTENER_VERSIONED
+#define GDSP_LISTENER_VERSIONED   "libcdsp_default_listener.so.1"
+#define GDSP_LISTENER_UNVERSIONED "libcdsp_default_listener.so"
 #endif
 
 typedef int (*dsp_default_listener_start_t)(int argc, char *argv[]);
 
+// Result struct for dlopen.
+struct dlopen_result {
+  void *handle;
+  const char *loaded_lib_name;
+};
+
+/**
+ * Attempts to load a shared library using dlopen.
+ * If the versioned name fails, falls back to the unversioned name.
+ * Returns both the handle and the name of the library successfully loaded.
+ */
+static struct dlopen_result try_dlopen(const char *versioned, const char *unversioned) {
+  struct dlopen_result result = { NULL, NULL };
+
+  result.handle = dlopen(versioned, RTLD_NOW);
+  if (result.handle) {
+    result.loaded_lib_name = versioned;
+    return result;
+  }
+
+  if (unversioned) {
+    VERIFY_IPRINTF("dlopen failed for %s: %s; attempting fallback %s",
+                   versioned, dlerror(), unversioned);
+    result.handle = dlopen(unversioned, RTLD_NOW);
+    if (result.handle) {
+      result.loaded_lib_name = unversioned;
+      return result;
+    }
+  }
+  return result;
+}
+
 int main(int argc, char *argv[]) {
   int nErr = 0;
-  void *dsphandler = NULL;
-  const char* lib_name;
+  struct dlopen_result dlres = { NULL, NULL };
+  const char* lib_versioned;
+  const char* lib_unversioned;
   const char* dsp_name;
   dsp_default_listener_start_t listener_start;
 
   #ifdef USE_ADSP
-    lib_name = ADSP_DEFAULT_LISTENER_NAME;
+    lib_versioned = ADSP_LISTENER_VERSIONED;
+    lib_unversioned = ADSP_LISTENER_UNVERSIONED;
     dsp_name = "ADSP";
   #elif defined(USE_SDSP)
-    lib_name = SDSP_DEFAULT_LISTENER_NAME;
+    lib_versioned = SDSP_LISTENER_VERSIONED;
+    lib_unversioned = SDSP_LISTENER_UNVERSIONED;
     dsp_name = "SDSP";
   #elif defined(USE_CDSP)
-    lib_name = CDSP_DEFAULT_LISTENER_NAME;
+    lib_versioned = CDSP_LISTENER_VERSIONED;
+    lib_unversioned = CDSP_LISTENER_UNVERSIONED;
     dsp_name = "CDSP";
   #elif defined(USE_GDSP)
-    lib_name = GDSP_DEFAULT_LISTENER_NAME;
+    lib_versioned = GDSP_LISTENER_VERSIONED;
+    lib_unversioned = GDSP_LISTENER_UNVERSIONED;
     dsp_name = "GDSP";
   #else
     goto bail;
@@ -55,14 +96,15 @@ int main(int argc, char *argv[]) {
   VERIFY_EPRINTF("%s daemon starting", dsp_name);
   
   while (1) {
-        if (NULL != (dsphandler = dlopen(lib_name,RTLD_NOW))) {
+        dlres = try_dlopen(lib_versioned, lib_unversioned);
+        if (NULL != dlres.handle) {
             if (NULL != (listener_start = (dsp_default_listener_start_t)dlsym(
-                              dsphandler, "adsp_default_listener_start"))) {
+                              dlres.handle, "adsp_default_listener_start"))) {
                 VERIFY_IPRINTF("adsp_default_listener_start called");
                 nErr = listener_start(argc, argv);
             }
-            if (0 != dlclose(dsphandler)) {
-              VERIFY_EPRINTF("dlclose failed for %s", lib_name);
+            if (0 != dlclose(dlres.handle)) {
+              VERIFY_EPRINTF("dlclose failed for %s", dlres.loaded_lib_name);
             }
         } else {
             VERIFY_EPRINTF("%s daemon error %s", dsp_name, dlerror());


### PR DESCRIPTION
Fixes #230 
- Currently `dsprpcd.c` attempts to `dlopen()` unversioned libraries such as `libadsp_default_listener.so`,  This breaks on distributions  which only ship ABI-versioned libraries in runtime packages. 
- It also risks binding to a different ABI in the future if a .so.2 is introduced, as mentioned in #230.

This patch updates the default listener library names to include `.so.1` and adds a fallback to the un-versioned `.so` for environments that still ship only the un-versioned file.