### PR TITLE
CI: push fastrpc tests to appropriate directories

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -31,25 +31,9 @@ runs:
         -v "$(dirname $PWD)":"$(dirname $PWD)" \
         ${{ inputs.docker_image }} bash -c "
           ./gitcompile --host=aarch64-linux-gnu
+          make install DESTDIR=${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc
         "
         echo "::endgroup::"
-
-        echo "Verify the compiled fastrpc files"
-        Files=(
-          src/.libs/libadsp_default_listener.so
-          src/.libs/libadsprpc.so
-          src/.libs/libcdsp_default_listener.so
-          src/.libs/libcdsprpc.so
-          src/.libs/libsdsp_default_listener.so
-          src/.libs/libsdsprpc.so
-          src/adsprpcd
-          src/cdsprpcd
-          src/sdsprpcd
-        )
-        for File in "${Files[@]}"
-        do 
-         if [ -f "$File" ] ; then echo "$File - Exists" ; else echo "$File - Not Exists" && exit 1 ; fi
-        done
 
     - name: Build kernel using Docker Image
       shell: bash
@@ -71,24 +55,6 @@ runs:
     - name: Package Files into ramdisk
       shell: bash
       run: |
-        # Create directories for pushing fastrpc binaries
-        mkdir -p ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib
-        mkdir -p ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
-
-        cd ${{ inputs.workspace_path }}
-
-        echo "Copy fastrpc files"
-        cp -rf src/.libs/libadsp_default_listener.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/.libs/libadsprpc.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/.libs/libcdsp_default_listener.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/.libs/libcdsprpc.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/.libs/libsdsp_default_listener.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/.libs/libsdsprpc.so* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/lib/
-        cp -rf src/adsprpcd src/cdsprpcd src/sdsprpcd ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin/
-
-        echo "Copy fastrpc test files"
-        cp -rf test/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/usr/bin
-
         echo "Package FastRPC firmware files"
         cp -r ${{ inputs.workspace_path }}/firmware_dir/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/
 


### PR DESCRIPTION
### Summary
This PR updates the deployment paths for `fastrpc_test` binaries and resources in the GitHub Actions LAVA test environment to reflect recent changes from https://github.com/qualcomm/fastrpc/pull/194.. It also ensures that environment variables for fastrpc testing are set up correctly, addressing test execution failures in GitHub Actions LAVA due to incorrect library paths.

### Root Cause
Recent updates to the fastrpc test framework now require that library stubs and skels reside in:
- `/usr/local/lib/fastrpc_test`
- `/usr/local/share/fastrpc_test`

Previously, these paths were not enforced, leading to test execution failures in the Test environment.

### Changes
- Eliminate the manual file copying step
- Utilize make install with DESTDIR=${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc to place the files in the necessary directories

### Reference
Upstream PR: https://github.com/qualcomm/fastrpc/pull/194
- Appends `testlibdir` and `testdspdir` to `LD_LIBRARY_PATH` and `DSP_LIBRARY_PATH`
- Updates `Makefile.am` to pass correct environment variables
- Simplifies installation and run instructions in `README.md`

### Impact
This change ensures compatibility with the updated fastrpc test framework and restores test execution.
