### PR TITLE
Add workflow to trigger a build of the package repo

### DIFF
--- a/.github/workflows/pkg-build-pr-check.yml
+++ b/.github/workflows/pkg-build-pr-check.yml
@@ -1,0 +1,39 @@
+
+name: Package Build PR Check
+description: |
+  This workflow will execute when a PR is open against the configured branch.
+  On top of whatever kind of CI/CD logic happens in this upstream repo, this 
+  workflow will make sure that what is attempted to be merged in the main release
+  branch won't break the debian package. The variable PKG_REPO_GITHUB_NAME needs to
+  be set in the repo where this file reside. This variable hold the packaging repo 
+  name on github associated to this upstream repo. What will happen is that the PR
+  triggering this workflow will go knock on the packaging repo's door and trigger
+  a full build of the package if it were to include these changes.
+
+on:
+  pull_request_target:
+    branches: [ main, development ]
+    types:
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+ contents: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  package-build-pr-check:
+    uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml@main
+    with:
+      qcom-build-utils-ref: main
+      upstream-repo: ${{github.repository}}
+      upstream-repo-ref: ${{github.head_ref}}
+      pkg-repo: ${{vars.PKG_REPO_GITHUB_NAME}}
+      pr-number: ${{github.event.pull_request.number}}
+    secrets:
+      TOKEN: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}


### PR DESCRIPTION
This workflow is an adapted copy of this workflow : https://github.com/qualcomm-linux/pkg-template/blob/main/.github/workflows/to_paste_in_upstream/pkg-build-pr-check.yml

With this workflow in position, a PR in the upstream project repo (this one) triggers a build or the sister package repo (in this case, it will be https://github.com/qualcomm-linux/pkg-fastrpc). The special repo variable PKG_REPO_GITHUB_NAME will need to be set to "qualcomm-linux/pkg-fastrpc" in this repo for this to work. 

See visit https://github.com/qualcomm-linux/pkg-template for more info about this whole CI workflow.

When a PR is open in this repo, this workflow will in turn call this one :
https://github.com/qualcomm-linux/qcom-build-utils/blob/main/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml
What it will do is try to compile the debian package from the "qualcomm-linux/pkg-fastrpc" but with the changes from the PR opened on this side added in order to test that the debian package will still build if this PR were to be merged. 

Ultimately, there will be even more tests downstream from that, like integration tests in a whole distro. 