### PR TITLE
inc: add required include files at instal

### DIFF
--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -1,16 +1,16 @@
 # Export fastrpc headers
 fastrpc_includedir       = $(includedir)/fastrpc
 fastrpc_include_HEADERS  = $(top_srcdir)/inc/AEEStdErr.h
+fastrpc_include_HEADERS += $(top_srcdir)/inc/AEEStdDef.h
 fastrpc_include_HEADERS += $(top_srcdir)/inc/remote.h
 fastrpc_include_HEADERS += $(top_srcdir)/inc/rpcmem.h
+fastrpc_include_HEADERS += $(top_srcdir)/inc/HAP_farf.h
+fastrpc_include_HEADERS += $(top_srcdir)/inc/HAP_debug.h
 
 noinst_HEADERS = \
 	AEEBufBound.h \
 	AEEQList.h \
-	AEEStdDef.h \
 	AEEstd.h \
-	HAP_debug.h \
-	HAP_farf.h \
 	HAP_farf_internal.h \
 	HAP_pls.h \
 	adsp_current_process.h \


### PR DESCRIPTION
Install  AEEStdDef.h, HAP_debug.h  and  HAP_farf.h that are required by to compile the skel and stub files generated by qaic compiler.

qaic compiler includes these header files, however fastrpc does not install these files, fix this by installing the required files.