### PR TITLE
Configure to run armor on aws runner

### DIFF
--- a/.github/workflows/run_armor.yml
+++ b/.github/workflows/run_armor.yml
@@ -37,7 +37,9 @@ permissions:
 
 jobs:
   RUN-ARMOR:
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: GHA-fastrpc-Prd-SelfHosted-RG
+      labels: [ self-hosted, fastrpc-prd-u2404-x64-large-od-ephem ]
     steps:
       - uses: actions/checkout@v4
       - name: Set event variables


### PR DESCRIPTION
Use aws runners in run_armor workflow, which is need to upload artifacts generated in RUN-ARMOR workflow to s3 location