### PR TITLE
Add systemd unit file for audiopd aDSP RPC daemon

### DIFF
--- a/files/Makefile.am
+++ b/files/Makefile.am
@@ -6,6 +6,7 @@ systemdsystemunitdir = @systemdsystemunitdir@
 # List of systemd service files to install
 dist_systemdsystemunit_DATA = \
 	adsprpcd.service \
+	adsprpcd_audiopd.service \
 	cdsprpcd.service \
 	cdsp1rpcd.service \
 	gdsp0rpcd.service \

--- a/files/adsprpcd_audiopd.service
+++ b/files/adsprpcd_audiopd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=audiopd aDSP RPC daemon
+After=dev-fastrpc-adsp.device dev-fastrpc-adsp-secure.device
+ConditionPathExists=|/dev/fastrpc-adsp
+ConditionPathExists=|/dev/fastrpc-adsp-secure
+
+[Service]
+Type=exec
+ExecStart=/usr/bin/adsprpcd audiopd
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a systemd service to manage the audiopd RPC daemon to support dynamic module loading on the aDSP.