### PR TITLE
Configure workflow to run Armor on AWS self-hosted runner

### DIFF
--- a/.github/workflows/run_armor.yml
+++ b/.github/workflows/run_armor.yml
@@ -37,7 +37,9 @@ permissions:
 
 jobs:
   RUN-ARMOR:
-    runs-on: ubuntu-22.04
+    runs-on:       
+      group: GHA-fastrpc-Prd-SelfHosted-RG
+      labels: [ self-hosted, fastrpc-prd-u2404-x64-large-od-ephem ]
     steps:
       - uses: actions/checkout@v4
       - name: Set event variables


### PR DESCRIPTION
**Summary**
- Updated runs-on to use the self-hosted runner group: GHA-fastrpc-Prd-SelfHosted-RG
- Configured AWS runners to support uploading artifacts to the designated S3 location.


**Why This Change?**
- Track changes and results generated from the repository
- Maintain backward compatibility at the repo level
- Display these details in the [Armor](https://armor.qualcomm.com/public-overview/public_headers) dashboard for better visibility

**Impact**
- Ensures seamless artifact uploads to S3 using AWS runners.
- Enhances observability and traceability for CI/CD workflows.
- No breaking changes introduced; backward compatibility is preserved.

CRs-Fixed: 4400385