### PR TITLE
feat(talos): add support for qcs615-ride target

### DIFF
--- a/ci/MACHINES.json
+++ b/ci/MACHINES.json
@@ -16,5 +16,11 @@
     "linuxFirmware": "qcs8300",
     "lavaDeviceName": "qcs8300-ride",
     "hexDSPBinary": "qcs8300"
+  },
+  "qcs615-ride": {
+  "deviceTree": "qcs615-ride",
+  "linuxFirmware": "qcs615",
+  "lavaDeviceName": "qcs615-ride",
+  "hexDSPBinary": "qcs615"
   }
 }


### PR DESCRIPTION
## Summary

Adds full Talos support for the **qcs615‑ride** target. This introduces the necessary Talos configuration to enable building, packaging, and testing on the qcs615‑ride platform.

## Changes

*   Added new Talos target configuration for **qcs615‑ride**.
*   Enabled correct device tree, firmware paths, DSP binary mapping, and LAVA job integration for this platform.

## Rationale

*   Provides Talos build and test enablement for the qcs615‑ride target.
*   Ensures the platform can be validated consistently through the existing Talos + LAVA workflow.

## Dependent Changes

<https://github.com/qualcomm-linux/job_render/pull/33>

## Testing

Validated using the **staging LAVA pipeline run**:  
<https://github.com/qualcomm-linux-stg/fastrpc/actions/runs/21627927984>

***
