### PR TITLE
Adds robust LAVA job monitoring in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,19 +78,36 @@ jobs:
         id: check_job
         run: |
           STATE=""
+          START_TIME=$(date +%s)
           while [ "$STATE" != "Finished" ]; do
             state=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep state)
             STATE=$(echo "$state" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
             echo "Current status: $STATE"
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$(((CURRENT_TIME - START_TIME)/3600))
+            if [ $ELAPSED_TIME -ge 2 ]; then
+                 echo "Timeout: 2 hours exceeded."
+                 summary=":x: Lava job exceeded time limit."
+                 echo "summary=$summary" >> $GITHUB_OUTPUT
+                 exit 1
+            fi
             sleep 30
           done
           health=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production jobs show $JOB_ID" | grep Health)
           HEALTH=$(echo "$health" | cut -d':' -f2 | sed 's/^ *//;s/ *$//')
           if [[ "$HEALTH" == "Complete" ]]; then
-            echo "Lava job passed."
-            summary=":heavy_check_mark: Lava job passed."
-            echo "summary=$summary" >> $GITHUB_OUTPUT
-            exit 0
+            TEST_RESULTS=$(docker run -i --rm --workdir="$PWD" -v "$(dirname $PWD)":"$(dirname $PWD)" ${{ inputs.docker_image }} sh -c "lavacli identities add --token ${{ secrets.LAVA_OSS_TOKEN }} --uri https://lava-oss.qualcomm.com/RPC2 --username ${{ secrets.LAVA_OSS_USER }} production && lavacli -i production results $JOB_ID" | grep fail || echo "Pass")
+            if [[ "$TEST_RESULTS" == "Pass" ]]; then
+               echo "Lava job passed."
+               summary=":heavy_check_mark: Lava job passed."
+               echo "summary=$summary" >> $GITHUB_OUTPUT
+               exit 0
+            else
+               echo "Lava job failed."
+               summary=":x: Lava job failed."
+               echo "summary=$summary" >> $GITHUB_OUTPUT
+               exit 1
+            fi
           else
             echo "Lava job failed."
             summary=":x: Lava job failed."


### PR DESCRIPTION
This change updates the workflow to:

- Check LAVA job status using lavacli inside the Docker container
- Handle additional states such as Cancelled, Incomplete, or timeout (>2 hours)
- Wait until the job reaches Finished before proceeding
- Fetch test results on completion and set pass/fail summary in GitHub Actions
- Update the step summary with job ID, URL, and final status

This improves reliability of LAVA-triggered test pipelines and prevents workflows from hanging or reporting incorrect results.