### PR TITLE
Handle RPC_PM_QOS command for backward compatibility

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -2294,6 +2294,11 @@ int remote_handle_control_domain(int domain, remote_handle64 h, uint32_t req,
       fastrpc_set_qos_latency(domain, h, FASTRPC_QOS_MAX_LATENCY_USEC);
       break;
     }
+    case RPC_PM_QOS: {
+      FARF(ALWAYS, "Warning: PM QoS is not supported; ignoring request and returning "
+           "success for backward compatibility");
+      break;
+    }
     case RPC_ADAPTIVE_QOS: {
       /* Enable adaptive QoS */
       VERIFY(AEE_SUCCESS ==


### PR DESCRIPTION
Some may send the RPC_PM_QOS control-domain command. The current driver does not support PM QoS operations, so return a false success to preserve compatibility and avoid triggering unexpected failures.