### PR TITLE
CI: Introduce precompiled kernel workflow and S3-based artifact reuse

### DIFF
--- a/.github/actions/aws_s3_helper/action.yml
+++ b/.github/actions/aws_s3_helper/action.yml
@@ -10,13 +10,21 @@ inputs:
     required: false
     default: ../artifacts/file_list.txt
   download_file:
-    description: S3 path of the file to download (e.g., path/to/your/file.txt). Used only in 'download' mode.
+    description: S3 key of the file to download (e.g., path/to/your/file.txt). Used only in 'download' mode.
     required: false
     default: ''
   download_location:
-    description: Local directory where the downloaded file should be placed. Used only in 'download' mode.
+    description: Local directory or file path where the downloaded file should be placed. Used only in 'download' mode.
     required: false
     default: .
+  artifacts:
+    description: >
+      Optional S3 key or prefix for upload/download.
+      - If ends with '/', it is treated as a prefix and the local filename is appended.
+      - If not ending with '/', it is treated as a full S3 key.
+      - If empty, a default location is derived.
+    required: false
+    default: ''
   mode:
     description: Mode of operation (single-upload, multi-upload, download)
     required: true
@@ -39,56 +47,148 @@ runs:
       shell: bash
       env:
         UPLOAD_LOCATION: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.workflow }}/${{ github.head_ref != '' && github.head_ref || github.run_id }}/${{ inputs.deviceTree }}/
+        DEFAULT_UPLOAD_LOCATION: ${{ github.repository_owner }}/${{ github.event.repository.name }}/
       run: |
+        set -euo pipefail
         echo "::group::$(printf '__________ %-100s' 'Process' | tr ' ' _)"
-        case "${{ inputs.mode }}" in
+
+        S3_BUCKET="${{ inputs.s3_bucket }}"
+        MODE="${{ inputs.mode }}"
+        LOCAL_FILE="${{ inputs.local_file }}"
+        ARTIFACTS="${{ inputs.artifacts }}"
+        DOWNLOAD_FILE="${{ inputs.download_file }}"
+        DOWNLOAD_LOCATION="${{ inputs.download_location }}"
+        WORKSPACE="${{ github.workspace }}"
+        DEVICE="${{ inputs.deviceTree }}"
+        UPLOAD_LOCATION="${{ env.UPLOAD_LOCATION }}"
+        DEFAULT_UPLOAD_LOCATION="${{ env.DEFAULT_UPLOAD_LOCATION }}"
+
+        # Helpers
+        _choose_upload_key() {
+          # $1: local path of file to upload
+          local local_path="$1"
+          local base; base="$(basename "$local_path")"
+
+          if [ -n "$ARTIFACTS" ]; then
+            # user provided a path; decide whether it's a prefix or a full key
+            if [[ "$ARTIFACTS" == */ ]]; then
+              # prefix: append filename
+              echo "${ARTIFACTS}${base}"
+            else
+              # full key
+              echo "${ARTIFACTS}"
+            fi
+          else
+            # default to computed upload location + filename
+            echo "${UPLOAD_LOCATION}${base}"
+          fi
+        }
+
+        case "${MODE}" in
           multi-upload)
-            echo "Uploading files to S3 bucket..."
+            echo "Uploading files to S3 bucket (multi-upload)..."
+            if [ ! -f "$LOCAL_FILE" ]; then
+              echo "ERROR: File list not found: $LOCAL_FILE" >&2
+              exit 1
+            fi
+
+            mkdir -p "${WORKSPACE}/${DEVICE}"
+            MANIFEST="${WORKSPACE}/${DEVICE}/presigned_urls_${DEVICE}.json"
+            echo "{" > "$MANIFEST"
             first_line=true
-            # Start the JSON object
-            mkdir -p "${{ github.workspace }}/${{ inputs.deviceTree }}"
-            echo "{" > ${{ github.workspace }}/${{ inputs.deviceTree }}/presigned_urls_${{ inputs.deviceTree }}.json
-            while IFS= read -r file; do
+
+            while IFS= read -r file || [ -n "$file" ]; do
+              # Skip blank and comment lines
+              [[ -z "${file// }" || "$file" =~ ^[[:space:]]*# ]] && continue
+
               if [ -f "$file" ]; then
-                echo "Uploading $file..."
-                aws s3 cp "$file" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}
-                echo "Uploaded $file to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
-                echo "Creating Pre-signed URL for $file..."
-                filename=$(basename "$file")
-                presigned_url=$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}$filename --expires-in 259200)
+                key="$(_choose_upload_key "$file")"
+                s3_uri="s3://${S3_BUCKET}/${key}"
+
+                echo "Uploading $file to $s3_uri ..."
+                aws s3 cp "$file" "$s3_uri" --sse AES256
+                echo "Uploaded $file to $s3_uri"
+
+                echo "Creating Pre-signed URL for $s3_uri ..."
+                presigned_url=$(aws s3 presign "$s3_uri" --expires-in 259200)
+
                 if [ "$first_line" = true ]; then
                   first_line=false
                 else
-                  echo "," >> ${{ github.workspace }}/${{ inputs.deviceTree }}/presigned_urls_${{ inputs.deviceTree }}.json
+                  echo "," >> "$MANIFEST"
                 fi
-                # Append the pre-signed URL to the file
-                echo " \"${file}\": \"${presigned_url}\"" >> ${{ github.workspace }}/${{ inputs.deviceTree }}/presigned_urls_${{ inputs.deviceTree }}.json
-                echo "Pre-signed URL for $file: $presigned_url"
+
+                printf ' "%s": "%s"' "$file" "$presigned_url" >> "$MANIFEST"
+                echo ""
               else
-                echo "Warning: $file does not exist or is not a regular file."
+                echo "Warning: $file does not exist or is not a regular file." >&2
               fi
-            done < "${{ inputs.local_file }}"
-            # Close the JSON object
-            echo "}" >> ${{ github.workspace }}/${{ inputs.deviceTree }}/presigned_urls_${{ inputs.deviceTree }}.json
+            done < "$LOCAL_FILE"
+
+
+            echo "}" >> "$MANIFEST"
             ;;
+
           single-upload)
             echo "Uploading single file to S3 bucket..."
-            aws s3 cp "${{ inputs.local_file }}" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}
-            echo "Uploaded ${{ inputs.local_file }} to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
-            echo "Creating Pre-signed URL for ${{ inputs.local_file }}..."
-            presigned_url=$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}${{ inputs.local_file }} --expires-in 259200)
+            if [ ! -f "$LOCAL_FILE" ]; then
+              echo "ERROR: Local file not found: $LOCAL_FILE" >&2
+              exit 1
+            fi
+
+            key="$(_choose_upload_key "$LOCAL_FILE")"
+            s3_uri="s3://${S3_BUCKET}/${key}"
+
+            echo "Uploading $LOCAL_FILE to $s3_uri ..."
+            aws s3 cp "$LOCAL_FILE" "$s3_uri" --sse AES256
+            echo "Uploaded $LOCAL_FILE to $s3_uri"
+
+            echo "Creating Pre-signed URL for $s3_uri ..."
+            presigned_url=$(aws s3 presign "$s3_uri" --expires-in 259200)
             echo "presigned_url=${presigned_url}" >> "$GITHUB_OUTPUT"
             ;;
+
           download)
-            #Download The required file from s3
-            echo "Downloading files from S3 bucket..."
-            aws s3 cp s3://${{ inputs.s3_bucket }}/${{ inputs.download_file }} ${{ inputs.download_location }}
+
+            echo "Downloading file from S3 bucket..."
+            # Priority:
+            #   - If ARTIFACTS is provided and not ending with '/', treat it as key
+            #   - Else if ARTIFACTS ends with '/', error (need a concrete key)
+            #   - Else use DOWNLOAD_FILE (must be set)
+            if [ -n "$ARTIFACTS" ]; then
+              if [[ "$ARTIFACTS" == */ ]]; then
+                echo "ERROR: 'artifacts' ends with '/'. Please provide a full S3 key (not a prefix) for download mode, or use 'download_file'." >&2
+                exit 1
+              fi
+              key="$ARTIFACTS"
+            else
+              if [ -z "$DOWNLOAD_FILE" ]; then
+                echo "ERROR: 'download_file' must be provided when 'artifacts' is empty in download mode." >&2
+                exit 1
+              fi
+              key="$DOWNLOAD_FILE"
+            fi
+            s3_uri="s3://${S3_BUCKET}/${key}"
+
+            # Ensure download location exists if it is a directory
+            if [ -d "$DOWNLOAD_LOCATION" ]; then
+              echo "Downloading $s3_uri -> ${DOWNLOAD_LOCATION}/"
+              aws s3 cp "$s3_uri" "${DOWNLOAD_LOCATION}/"
+            else
+              mkdir -p "$(dirname "$DOWNLOAD_LOCATION")"
+              echo "Downloading $s3_uri -> ${DOWNLOAD_LOCATION}"
+              aws s3 cp "$s3_uri" "${DOWNLOAD_LOCATION}"
+            fi
+
+            echo "Downloaded ${s3_uri} to ${DOWNLOAD_LOCATION}"
             ;;
           *)
             echo "Invalid mode. Use 'upload' or 'download'."
             exit 1
             ;;
         esac
+
+        echo "::endgroup::"
 
     - name: Upload artifacts
       if: ${{ inputs.mode == 'multi-upload' }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,6 +16,10 @@ inputs:
   workspace_path:
     description: Workspace path
     required: true
+  deviceTree:
+    description: Target device Tree name or identifier, used to organize uploads in S3.
+    type: string
+    required: true
 
 runs:
   using: "composite"
@@ -35,26 +39,29 @@ runs:
         "
         echo "::endgroup::"
 
-    - name: Build kernel using Docker Image
-      shell: bash
-      run: |
-        cd ${{ inputs.workspace_path }}/kernel
-
-        echo "::group::$(printf '__________ %-100s' 'Compile kernel' | tr ' ' _)"
-        docker run -i --rm \
-          --user $(id -u):$(id -g) \
-          --workdir="$PWD" \
-          -v "$(dirname $PWD)":"$(dirname $PWD)" \
-          ${{ inputs.docker_image }} bash -c "
-            make O=../kobj defconfig
-            make O=../kobj -j$(nproc)
-            make O=../kobj -j$(nproc) dir-pkg INSTALL_MOD_STRIP=1
-          "
-        echo "::endgroup::"
+    - name: Download Kernel artifact
+      uses: qualcomm-linux-stg/fastrpc/.github/actions/aws_s3_helper@development
+      with:
+        s3_bucket: qli-stg-fastrpc-gh-artifacts
+        artifacts:  kernel-artifact/kobj.tar.gz 
+        deviceTree: false
+        download_location: ${{ inputs.workspace_path }}
+        mode: download
 
     - name: Package Files into ramdisk
       shell: bash
       run: |
+        echo "Extracting kobj.tar.gz"
+        ls -la ${{ inputs.workspace_path }}/
+        mkdir -p extracted_kobj
+        tar -xzf "${{ inputs.workspace_path }}/kobj.tar.gz" -C extracted_kobj
+        echo "Contents of extracted_kobj:"
+        find extracted_kobj -type d
+        # Move extracted folder to kobj
+        rm -rf kobj
+        mv extracted_kobj/kobj kobj
+        ls -la kobj
+
         echo "Package FastRPC firmware files"
         cp -r ${{ inputs.workspace_path }}/firmware_dir/* ${{ inputs.workspace_path }}/artifacts/ramdisk_fastrpc/
 

--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -6,7 +6,6 @@ description: |
   It clones and copies FastRPC hexagon DSP binaries and 
   Linux firmware (specifically QCOM firmware) based on 
   the provided `hexDSPBinary` and `linuxFirmware` input. 
-  It also clones the `qualcomm-linux/kernel` repository.
   The action sets an output `workspace_path` to the GitHub
    workspace directory.
 
@@ -106,21 +105,6 @@ runs:
         echo "Listing contents of firmware_dir recursively..."
         find firmware_dir -type d -print
         find firmware_dir -type f -print
-
-    - name: Configure git
-      shell: bash
-      run: |
-        git config --global user.name "github-actions"
-        git config --global user.email "github-actions@github.com"
-
-    - name: Clone kernel repositories
-      shell: bash
-      run: |
-        cd ${{ github.workspace }}
-        git clone https://github.com/qualcomm-linux/kernel.git
-        cd kernel
-        git fetch origin
-        git checkout qcom-next
 
     - name: Set workspace path
       id: set-workspace

--- a/.github/workflows/nightly-kernel-build.yml
+++ b/.github/workflows/nightly-kernel-build.yml
@@ -7,14 +7,14 @@ name: Nightly Build kernel and upload artifacts
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Runs every Sunday at midnight UTC
+    - cron: '0 0 * * 0'  # Runs at 00:00, only on Sunday UTC
   workflow_dispatch:     # Allows manual trigger
 
 jobs:
   build-and-upload:
-    runs-on:
+    runs-on: 
       group: GHA-fastrpc-Prd-SelfHosted-RG
-      labels: [ self-hosted, fastrpc-prd-u2404-x64-large-od-ephem ] 
+      labels: [ self-hosted, fastrpc-prd-u2404-x64-large-od-ephem ]
     steps:
       # Checkout fastrpc-image repository to get the Dockerfile
       - name: Checkout fastrpc-image repo for Dockerfile
@@ -85,4 +85,5 @@ jobs:
           s3_bucket: qli-prd-fastrpc-gh-artifacts
           local_file: ${{ github.workspace }}/build_output/kobj.tar.gz
           mode: single-upload
+          artifacts: kernel-artifact/kobj.tar.gz 
           deviceTree: false

--- a/.github/workflows/sync_build.yml
+++ b/.github/workflows/sync_build.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           docker_image: ${{ inputs.docker_image }}
           workspace_path: ${{ steps.sync.outputs.workspace_path }}
+          deviceTree: ${{ inputs.deviceTree }}
 
       - name: Create file list for artifacts upload
         run: |


### PR DESCRIPTION
## 📌 Summary

This PR introduces support for using a precompiled kernel image within CI. A nightly automation now builds the kernel once and uploads the generated artifacts to S3. PR workflows download these nightly kernel artifacts to generate the ramdisk, eliminating the need for kernel compilation inside each PR.

---

## 🔄 What’s Changed

- Added a nightly kernel build workflow that compiles the kernel and uploads artifacts to S3.
- Updated PR workflows to:
  - Download precompiled nightly kernel artifacts.
  - Use the downloaded kernel to generate the ramdisk.
  - Remove redundant kernel compilation steps.

---

## 🚀 Benefits

- **Saves ~30–50 minutes per PR** by avoiding kernel compilation.
- **Reduces CI compute usage** and avoids rebuilding the same kernel across variants.
- **Improves PR turnaround time**, enabling faster developer feedback.
- **Increases CI reliability**, removing kernel‑build related failures and noise.

---

## ✅ Verification

- Nightly workflow successfully validated in staging.
- PR workflows tested using downloaded nightly kernel artifacts.

🔗 **Staging Run:**  
Upload - https://github.com/qualcomm-linux-stg/fastrpc/actions/runs/21540229903/job/62073492385
Download - https://github.com/qualcomm-linux-stg/fastrpc/actions/runs/21541159520/job/62075780977

Before this change : 
<img width="1163" height="485" alt="image" src="https://github.com/user-attachments/assets/820a3715-0d4f-47c2-9841-2115c529c1c7" />

After this change :
<img width="1214" height="531" alt="image" src="https://github.com/user-attachments/assets/5e02a433-fb7c-4dc4-8457-f34268694bf6" />

---

## 📎 Additional Notes

- This unifies kernel usage across CI.
- Moves the system to a single‑source‑of‑truth kernel build per weekly.

Closes qualcomm/fastrpc#244