### PR TITLE
CI: Use Generic overlay without kselftest and env-based test method

### DIFF
--- a/.github/actions/lava_job_render/action.yml
+++ b/.github/actions/lava_job_render/action.yml
@@ -178,6 +178,7 @@ runs:
           -e TARGET_DTB="${{ env.DEVICE_TREE }}" \
           ${{ inputs.docker_image }} \
           sh -c 'export BOOT_METHOD=fastboot && \
+            export TEST_METHOD=generic && \
             export TARGET=${TARGET} && \
             export TARGET_DTB=${TARGET_DTB} && \
             python3 lava_Job_definition_generator.py --localjson ./data/cloudData.json --fastrpc-premerge'


### PR DESCRIPTION
## Summary

Adopts the **Generic overlay without kselftest** and enables **environment‑based** test selection in the LAVA job definition generator. This allows us to drop kselftest and run only the required tests by setting `TEST_METHOD=generic`.

## Changes

*   Switched to using the **Generic overlay (no kselftest)** in the LAVA job generation flow.

## Rationale

*   Removes unnecessary kselftest dependencies for our targets.
*   Provides a lightweight overlay for platforms that do not require kselftest.
*   Reduces image footprint and simplifies test execution.

## Dependent Changes

*   <https://github.com/qualcomm-linux/job_render/pull/33>

## Testing

Validated using the staging LAVA pipeline run: 
**<https://github.com/qualcomm-linux-stg/fastrpc/actions/runs/21627927984>**

## Notes

*   Backward compatible: default behavior remains unchanged if `TEST_METHOD` is not set.
*   Overlay change only removes kselftest; all other components remain unaffected.

***
