### PR TITLE
fix(prod): update S3 bucket to qli-prd-fastrpc-gh-artifacts

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -40,9 +40,9 @@ runs:
         echo "::endgroup::"
 
     - name: Download Kernel artifact
-      uses: qualcomm-linux-stg/fastrpc/.github/actions/aws_s3_helper@development
+      uses: qualcomm/fastrpc/.github/actions/aws_s3_helper@development
       with:
-        s3_bucket: qli-stg-fastrpc-gh-artifacts
+        s3_bucket: qli-prd-fastrpc-gh-artifacts
         artifacts:  kernel-artifact/kobj.tar.gz 
         deviceTree: false
         download_location: ${{ inputs.workspace_path }}


### PR DESCRIPTION
**Bug Fix:** Production was incorrectly referencing the staging artifacts bucket
(qli-stg-fastrpc-gh-artifacts), causing 403/NotFound errors during runtime
artifact fetches.

Updated the prod configuration to use the correct production bucket:
qli-prd-fastrpc-gh-artifacts.