### PR TITLE
pkg-build-pr-check: Fix repo/ref when fork PR

### DIFF
--- a/.github/workflows/pkg-build-pr-check.yml
+++ b/.github/workflows/pkg-build-pr-check.yml
@@ -31,8 +31,8 @@ jobs:
     uses: qualcomm-linux/qcom-build-utils/.github/workflows/qcom-upstream-pr-pkg-build-reusable-workflow.yml@main
     with:
       qcom-build-utils-ref: main
-      upstream-repo: ${{github.repository}}
-      upstream-repo-ref: ${{github.head_ref}}
+      upstream-repo: ${{ github.event.pull_request.head.repo.full_name }}
+      upstream-repo-ref: ${{ github.event.pull_request.head.ref }}
       pkg-repo: ${{vars.PKG_REPO_GITHUB_NAME}}
       pr-number: ${{github.event.pull_request.number}}
     secrets:


### PR DESCRIPTION
The pkg-build-pr-check workflow triggers a build of the associated pkg-repo of the upstream project. 
Before this fix, the workflow logic did not handle properly when the PR was from a fork of the upstream project as opposed to a branch from the repo itseld.  Now, the proper repo and ref are forwarded to the reusable workflow.

Note that for this to work, the forked repo needs to be public. This should logically always be the case because our upstream repos are public to begin with, and a fork from a public repo has not choice but to be public as well. 
