### PR TITLE
Refactor memory mapping with DSP address tracking

### DIFF
--- a/inc/fastrpc_mem.h
+++ b/inc/fastrpc_mem.h
@@ -73,4 +73,33 @@ int fastrpc_buffer_ref(int domain, int fd, int ref, void **va, size_t *size);
  */
 void remote_register_buf(void *buf, int size, int fd);
 
+/*
+ * Internal function to map a buffer and return the DSP virtual address.
+ * Creates a mapping on the DSP and stores the mapping information in the static map list.
+ *
+ * @param domain The DSP domain ID (-1 for current domain)
+ * @param fd File descriptor of the buffer
+ * @param vaddr Virtual address of the buffer on CPU side
+ * @param offset Offset from the beginning of the buffer (must be 0)
+ * @param length Size of buffer in bytes
+ * @param flags Mapping flags
+ * @param raddr Output: DSP virtual address of the mapped buffer
+ *
+ * @return 0 on success, error code on failure
+ */
+int fastrpc_mmap_internal(int domain, int fd, void *vaddr, int offset, size_t length, uint32_t flags, uint64_t *raddr);
+
+/*
+ * Internal function to unmap a buffer using the DSP virtual address.
+ * Looks up the mapping in the static map list using the DSP virtual address,
+ * then performs the unmap operation and removes the mapping from the list.
+ *
+ * @param domain The DSP domain ID (-1 for current domain)
+ * @param raddr DSP virtual address of the mapped buffer
+ * @param length Size of buffer in bytes to unmap
+ *
+ * @return 0 on success, error code on failure
+ */
+int fastrpc_munmap_internal(int domain, uint64_t raddr, size_t length);
+
 #endif //FASTRPC_MEM_H

--- a/inc/rpcmem_internal.h
+++ b/inc/rpcmem_internal.h
@@ -7,22 +7,6 @@
 #include "rpcmem.h"
 
 /*
- * rpcmem_set_dmabuf_name() - API to set name for DMA allocated buffer.
- *                            Name string updates as follows.
- *                            Heap : dsp_<pid>_<tid>_<remote-flags>
- *                            Non-heap : apps_<pid>_<tid>_<rpcflags>
- *
- * @name    : Pointer to string, "dsp" for heap buffers, "apps" for
- *            non-heap buffers
- * @fd      : File descriptor of buffer
- * @heapid  : Heap ID used for memory allocation
- * @buf     : Pointer to buffer start address
- * @rpcflags: Memory flags describing attributes of allocation
- * Return   : 0 on success, valid non-zero error code on failure
- */
-int rpcmem_set_dmabuf_name(const char *name, int fd, int heapid,
-				void *buf, uint32_t rpc_flags);
-/*
  * returns an file descriptor associated with the address
  */
 int rpcmem_to_fd_internal(void *po);

--- a/src/apps_mem_imp.c
+++ b/src/apps_mem_imp.c
@@ -149,7 +149,6 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
     VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
             AEE_ENORPCMEMORY);
     VERIFYC(0 < (fd = rpcmem_to_fd_internal(buf)), AEE_EBADFD);
-    rpcmem_set_dmabuf_name("dsp", fd, heapid, buf, lflags);
     /* Using FASTRPC_MAP_FD_DELAYED as only HLOS mapping is reqd at this point
      */
     VERIFY(AEE_SUCCESS == (nErr = fastrpc_mmap(domain, fd, buf, 0, len,
@@ -177,7 +176,6 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
               AEE_ENORPCMEMORY);
       fd = rpcmem_to_fd_internal(buf);
       VERIFYC(fd > 0, AEE_EBADPARM);
-      rpcmem_set_dmabuf_name("dsp", fd, heapid, buf, lflags);
     }
     VERIFY(AEE_SUCCESS ==
            (nErr = remote_mmap64_internal(fd, rflags, (uint64_t)buf, len,

--- a/src/apps_mem_imp.c
+++ b/src/apps_mem_imp.c
@@ -163,23 +163,13 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
      */
     *vadsp = (uint64_t)fd;
   } else {
-    /* Memory for unsignedPD's user-heap will be allocated in userspace for
-     * security reasons. Memory for signedPD's user-heap will be allocated in
-     * kernel.
-     */
-    if (((rflags != ADSP_MMAP_ADD_PAGES) &&
-         (rflags != ADSP_MMAP_ADD_PAGES_LLC)) ||
-        (((rflags == ADSP_MMAP_ADD_PAGES) ||
-          (rflags == ADSP_MMAP_ADD_PAGES_LLC)) &&
-         (unsigned_module && ualloc_support))) {
-      VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
-              AEE_ENORPCMEMORY);
-      fd = rpcmem_to_fd_internal(buf);
-      VERIFYC(fd > 0, AEE_EBADPARM);
-    }
+    VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
+            AEE_ENORPCMEMORY);
+    fd = rpcmem_to_fd_internal(buf);
+    VERIFYC(fd > 0, AEE_EBADPARM);
     VERIFY(AEE_SUCCESS ==
-           (nErr = remote_mmap64_internal(fd, rflags, (uint64_t)buf, len,
-                                          (uint64_t *)vadsp)));
+           (nErr = fastrpc_mmap_internal(domain, fd, buf, 0, len,
+                                         rflags, vadsp)));
     pbuf = (uint64_t)buf;
     *vapps = pbuf;
     minfo->vapps = *vapps;
@@ -250,17 +240,27 @@ __QAIC_IMPL(apps_mem_request_unmap64)(uint64_t vadsp,
   pthread_mutex_unlock(&me->mem_mut);
 
   /* If apps_mem_request_map64 was called with flag FASTRPC_ALLOC_HLOS_FD,
-   * use fastrpc_munmap else use remote_munmap64 to unmap.
+   * use fastrpc_munmap. For ADSP_MMAP_HEAP_ADDR and ADSP_MMAP_REMOTE_HEAP_ADDR,
+   * use remote_munmap64. For other cases, use fastrpc_munmap_internal.
    */
    if(mfree && mfree->rflags == FASTRPC_ALLOC_HLOS_FD) {
       fd = (int)vadsp;
       VERIFY(AEE_SUCCESS == (nErr = fastrpc_munmap(domain, fd, 0, len)));
+   } else if (mfree && (mfree->rflags == ADSP_MMAP_HEAP_ADDR ||
+                        mfree->rflags == ADSP_MMAP_REMOTE_HEAP_ADDR)) {
+      /* These cases use remote_mmap64_internal, so use remote_munmap64 */
+      VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
    } else if (mfree || fastrpc_get_pd_type(domain) == AUDIO_STATICPD){
       /*
        * Map info not available for Audio static PD after daemon reconnect,
        * So continue to unmap to avoid driver global maps leak.
+       * For other cases, use fastrpc_munmap_internal as they were mapped with fastrpc_mmap_internal.
        */
-      VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
+      if (mfree) {
+         VERIFY(AEE_SUCCESS == (nErr = fastrpc_munmap_internal(domain, (uint64_t)vadsp, len)));
+      } else {
+         VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
+      }
       if (!mfree)
          goto bail;
    }

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -440,51 +440,37 @@ int fdlist_fd_from_buf(void *buf, int bufLen, int *nova, void **base, int *attr,
   return 0;
 }
 
-int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
-                 enum fastrpc_map_flags flags) {
+/**
+ * Helper function to perform complete mmap operation including error handling
+ * Returns 0 on success, error code on failure
+ * On success, vaddrout contains the DSP virtual address
+ */
+static int fastrpc_mmap_helper(int *domain, int fd, void *vaddr, int offset,
+                                size_t length, uint32_t flags, int attrs,
+                                uint64_t *vaddrout) {
   struct fastrpc_map map = {0};
-  int nErr = 0, dev = -1, iocErr = 0, attrs = 0, ref = 0;
-  uint64_t vaddrout = 0;
+  int nErr = 0, dev = -1, iocErr = 0, ref = 0;
   struct static_map *mNode = NULL, *tNode = NULL;
   QNode *pn, *pnn;
 
-  VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
-
-  FARF(RUNTIME_RPC_HIGH,
-       "%s: domain %d fd %d addr %p length 0x%zx flags 0x%x offset 0x%x",
-       __func__, domain, fd, vaddr, length, flags, offset);
-
-  /**
-   * Mask is applied on "flags" parameter to extract map control flags
-   * and SMMU mapping control attributes. Currently no attributes are
-   * suppported. It allows future extension of the fastrpc_mmap API
-   * for SMMU mapping control attributes.
-   */
-  attrs = flags & (~FASTRPC_MAP_FLAGS_MASK);
-  flags = flags & FASTRPC_MAP_FLAGS_MASK;
-  VERIFYC(fd >= 0 && offset == 0 && attrs == 0, AEE_EBADPARM);
-  VERIFYC(flags >= 0 && flags < FASTRPC_MAP_MAX &&
-              flags != FASTRPC_MAP_RESERVED,
-          AEE_EBADPARM);
-
   // Get domain and open session if not already open
-  if (domain == -1) {
-    domain = get_current_domain();
+  if (*domain == -1) {
+    *domain = get_current_domain();
   }
-  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
-  FASTRPC_GET_REF(domain);
-  VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(*domain), AEE_EBADPARM);
+  FASTRPC_GET_REF(*domain);
+  VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(*domain, &dev)));
   VERIFYC(-1 != dev, AEE_ERPC);
 
   /* Search for mapping in current session static map list */
-  pthread_mutex_lock(&smaplst[domain].mut);
-  QLIST_NEXTSAFE_FOR_ALL(&smaplst[domain].ql, pn, pnn) {
+  pthread_mutex_lock(&smaplst[*domain].mut);
+  QLIST_NEXTSAFE_FOR_ALL(&smaplst[*domain].ql, pn, pnn) {
     tNode = STD_RECOVER_REC(struct static_map, qn, pn);
     if (tNode->map.fd == fd) {
       break;
     }
   }
-  pthread_mutex_unlock(&smaplst[domain].mut);
+  pthread_mutex_unlock(&smaplst[*domain].mut);
 
   // Raise error if map found already
   if (tNode) {
@@ -505,13 +491,13 @@ int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
   map.m.vaddrout = 0;
   mNode->map = map.m;
   iocErr = ioctl_mmap(dev, MEM_MAP, flags, attrs, fd, offset, length,
-                      (uint64_t)vaddr, &vaddrout);
+                      (uint64_t)vaddr, vaddrout);
   if (!iocErr) {
-    mNode->map.vaddrout = vaddrout;
+    mNode->map.vaddrout = *vaddrout;
     mNode->refs = 1;
-    pthread_mutex_lock(&smaplst[domain].mut);
-    QList_AppendNode(&smaplst[domain].ql, &mNode->qn);
-    pthread_mutex_unlock(&smaplst[domain].mut);
+    pthread_mutex_lock(&smaplst[*domain].mut);
+    QList_AppendNode(&smaplst[*domain].ql, &mNode->qn);
+    pthread_mutex_unlock(&smaplst[*domain].mut);
     mNode = NULL;
   } else if (errno == ENOTTY ||
              iocErr == (int)(DSP_AEE_EOFFSET | AEE_EUNSUPPORTED)) {
@@ -521,21 +507,57 @@ int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
     nErr = AEE_EFAILED;
     goto bail;
   }
+
 bail:
-  FASTRPC_PUT_REF(domain);
+  FASTRPC_PUT_REF(*domain);
   if (nErr) {
     if (iocErr == 0) {
       errno = 0;
     }
     FARF(ERROR,
-         "Error 0x%x: %s failed to map buffer fd %d, addr %p, length 0x%zx, "
+         "Error 0x%x: %s failed for fd %d, addr %p, length 0x%zx, "
          "domain %d, flags 0x%x, ioctl ret 0x%x, errno %s",
-         nErr, __func__, fd, vaddr, length, domain, flags, iocErr,
+         nErr, __func__, fd, vaddr, length, *domain, flags, iocErr,
          strerror(errno));
   }
   if (mNode) {
     free(mNode);
     mNode = NULL;
+  }
+  return nErr;
+}
+
+int fastrpc_mmap(int domain, int fd, void *vaddr, int offset, size_t length,
+                 enum fastrpc_map_flags flags) {
+  int nErr = 0, attrs = 0;
+  uint64_t vaddrout = 0;
+
+  VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
+
+  FARF(RUNTIME_RPC_HIGH,
+       "%s: domain %d fd %d addr %p length 0x%zx flags 0x%x offset 0x%x",
+       __func__, domain, fd, vaddr, length, flags, offset);
+
+  /**
+   * Mask is applied on "flags" parameter to extract map control flags
+   * and SMMU mapping control attributes. Currently no attributes are
+   * suppported. It allows future extension of the fastrpc_mmap API
+   * for SMMU mapping control attributes.
+   */
+  attrs = flags & (~FASTRPC_MAP_FLAGS_MASK);
+  flags = flags & FASTRPC_MAP_FLAGS_MASK;
+  VERIFYC(fd >= 0 && offset == 0 && attrs == 0, AEE_EBADPARM);
+  VERIFYC(flags >= 0 && flags < FASTRPC_MAP_MAX &&
+              flags != FASTRPC_MAP_RESERVED,
+          AEE_EBADPARM);
+
+  nErr = fastrpc_mmap_helper(&domain, fd, vaddr, offset, length, flags, attrs,
+                              &vaddrout);
+
+bail:
+  if (nErr) {
+    FARF(ERROR, "Error 0x%x: %s failed for fd %d, addr %p, length 0x%zx, domain %d, flags 0x%x",
+         nErr, __func__, fd, vaddr, length, domain, flags);
   }
   return nErr;
 }
@@ -610,6 +632,104 @@ bail:
          "Error 0x%x: %s failed fd %d, vaddr %p, length 0x%zx, domain %d, "
          "ioctl ret 0x%x, errno %s",
          nErr, __func__, fd, vaddr, length, domain, iocErr, strerror(errno));
+  }
+  return nErr;
+}
+
+int fastrpc_mmap_internal(int domain, int fd, void *vaddr, int offset,
+                           size_t length, uint32_t flags, uint64_t *raddr) {
+  int nErr = 0, attrs = 0;
+
+  VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
+
+  VERIFYC(raddr != NULL, AEE_EBADPARM);
+
+  FARF(RUNTIME_RPC_HIGH,
+       "%s: domain %d fd %d addr %p length 0x%zx flags 0x%x offset 0x%x",
+       __func__, domain, fd, vaddr, length, flags, offset);
+
+  attrs = flags & (~FASTRPC_MAP_FLAGS_MASK);
+  flags = flags & FASTRPC_MAP_FLAGS_MASK;
+  VERIFYC(fd >= 0 && offset == 0 && attrs == 0, AEE_EBADPARM);
+
+  nErr = fastrpc_mmap_helper(&domain, fd, vaddr, offset, length, flags, attrs,
+                              raddr);
+
+bail:
+  if (nErr) {
+    FARF(ERROR, "Error 0x%x: %s failed for fd %d, addr %p, length 0x%zx, domain %d, flags 0x%x",
+         nErr, __func__, fd, vaddr, length, domain, flags);
+  }
+  return nErr;
+}
+
+int fastrpc_munmap_internal(int domain, uint64_t raddr, size_t length) {
+  int nErr = 0, dev = -1, iocErr = 0, locked = 0, ref = 0;
+  struct static_map *mNode = NULL;
+  QNode *pn, *pnn;
+
+  VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
+
+  FARF(RUNTIME_RPC_HIGH, "%s: domain %d raddr 0x%llx length 0x%zx", __func__,
+       domain, raddr, length);
+  if (domain == -1) {
+    domain = get_current_domain();
+  }
+  VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_EBADPARM);
+  FASTRPC_GET_REF(domain);
+  VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
+  /**
+   * Search for mapping in current static map list using DSP virtual address (raddr).
+   */
+  pthread_mutex_lock(&smaplst[domain].mut);
+  locked = 1;
+  QLIST_NEXTSAFE_FOR_ALL(&smaplst[domain].ql, pn, pnn) {
+    mNode = STD_RECOVER_REC(struct static_map, qn, pn);
+    if (mNode->map.vaddrout == raddr) {
+      FARF(RUNTIME_RPC_HIGH, "%s: unmap found for raddr 0x%llx domain %d", __func__,
+           raddr, domain);
+      break;
+    }
+  }
+  VERIFYC(mNode && mNode->map.vaddrout == raddr, AEE_ENOSUCHMAP);
+  if (mNode->refs > 1) {
+    FARF(ERROR, "%s: Attempt to unmap raddr 0x%llx with %d outstanding references",
+         __func__, raddr, mNode->refs - 1);
+    nErr = AEE_EBADPARM;
+    goto bail;
+  }
+  mNode->refs = 0;
+  locked = 0;
+  pthread_mutex_unlock(&smaplst[domain].mut);
+
+  iocErr = ioctl_munmap(dev, MEM_UNMAP, 0, 0, mNode->map.fd, mNode->map.length,
+                        mNode->map.vaddrout);
+  pthread_mutex_lock(&smaplst[domain].mut);
+  locked = 1;
+  if (iocErr == 0) {
+    QNode_DequeueZ(&mNode->qn);
+    free(mNode);
+    mNode = NULL;
+  } else if (errno == ENOTTY || errno == EINVAL) {
+    nErr = AEE_EUNSUPPORTED;
+  } else {
+    mNode->refs = 1;
+    nErr = AEE_EFAILED;
+  }
+bail:
+  if (locked == 1) {
+    locked = 0;
+    pthread_mutex_unlock(&smaplst[domain].mut);
+  }
+  FASTRPC_PUT_REF(domain);
+  if (nErr) {
+    if (iocErr == 0) {
+      errno = 0;
+    }
+    FARF(ERROR,
+         "Error 0x%x: %s failed raddr 0x%llx, length 0x%zx, domain %d, "
+         "ioctl ret 0x%x, errno %s",
+         nErr, __func__, raddr, length, domain, iocErr, strerror(errno));
   }
   return nErr;
 }

--- a/src/rpcmem_linux.c
+++ b/src/rpcmem_linux.c
@@ -118,12 +118,6 @@ void rpcmem_deinit() {
   pthread_mutex_destroy(&rpcmt);
 }
 
-int rpcmem_set_dmabuf_name(const char *name, int fd, int heapid,
-			void *buf, uint32_t rpcflags) {
-        // Dummy call where DMABUF is not used
-        return 0;
-}
-
 int rpcmem_to_fd_internal(void *po) {
   struct rpc_info *rinfo, *rfree = 0;
   QNode *pn, *pnn;


### PR DESCRIPTION
Refactor memory mapping implementation to use internal functions with DSP virtual address tracking and simplify allocation logic.

- Remove unused rpcmem_set_dmabuf_name() dummy function
- Add fastrpc_mmap_internal() and fastrpc_munmap_internal() for DSP address management
- Extract common mmap logic into fastrpc_mmap_helper() to eliminate code duplication
- Simplify apps_mem_request_map64() to always allocate in userspace
- Route unmap operations based on mapping type in apps_mem_request_unmap64()
