### PR TITLE
Drop ADSP_AVS_* env support from path resolver

### DIFF
--- a/inc/apps_std_internal.h
+++ b/inc/apps_std_internal.h
@@ -18,7 +18,6 @@
 // Environment variable name, that can be used to override the search paths
 #define ADSP_LIBRARY_PATH "ADSP_LIBRARY_PATH"
 #define DSP_LIBRARY_PATH "DSP_LIBRARY_PATH"
-#define ADSP_AVS_PATH "ADSP_AVS_CFG_PATH"
 #define MAX_NON_PRELOAD_LIBS_LEN 2048
 #define FILE_EXT ".so"
 
@@ -27,11 +26,6 @@
 #endif
 #ifndef VENDOR_DOM_LOCATION
 #define VENDOR_DOM_LOCATION "/vendor/dsp/xdsp/"
-#endif
-
-// Search path used by fastRPC for acdb path
-#ifndef ADSP_AVS_CFG_PATH
-#define ADSP_AVS_CFG_PATH ";/etc/acdbdata/;"
 #endif
 
 int fopen_from_dirlist(const char *dirList, const char *delim, 

--- a/src/apps_std_imp.c
+++ b/src/apps_std_imp.c
@@ -970,20 +970,6 @@ static int get_dirlist_from_env(const char *envvarname, char **ppDirList) {
       // Append default DSP_SEARCH_PATH to user defined env
       strlcat(envList, dsp_search_path, envListPrependLen);
       envListLen = envListPrependLen;
-    } else if (strncmp(envvarname, ADSP_AVS_PATH,
-                           strlen(ADSP_AVS_PATH)) == 0) {
-      envListPrependLen = envListLen + strlen(ADSP_AVS_CFG_PATH);
-      if (envLenGuess < envListPrependLen) {
-        FREEIF(envListBuf);
-        VERIFYC(envListBuf =
-                    realloc(envListBuf, sizeof(char) * envListPrependLen),
-                AEE_ENOMEMORY);
-        envList = envListBuf;
-        VERIFY(0 == (nErr = apps_std_getenv(envvarname, envList,
-                                            envListPrependLen, &listLen)));
-      }
-      strlcat(envList, ADSP_AVS_CFG_PATH, envListPrependLen);
-      envListLen = envListPrependLen;
     }
   } else if (strncmp(envvarname, ADSP_LIBRARY_PATH,
                          strlen(ADSP_LIBRARY_PATH)) == 0 ||
@@ -991,10 +977,6 @@ static int get_dirlist_from_env(const char *envvarname, char **ppDirList) {
                          strlen(DSP_LIBRARY_PATH)) == 0) {
     envListLen = listLen =
         1 + strlcpy(envListBuf, dsp_search_path, envLenGuess);
-  } else if (strncmp(envvarname, ADSP_AVS_PATH,
-                         strlen(ADSP_AVS_PATH)) == 0) {
-    envListLen = listLen =
-        1 + strlcpy(envListBuf, ADSP_AVS_CFG_PATH, envLenGuess);
   }
 
   /*


### PR DESCRIPTION
Remove unused ADSP_AVS_CFG_PATH default and ADSP_AVS_PATH handling from get_dirlist_from_env().