### PR TITLE
Remove DEFAULT_DEVICE fallback to prevent cross-domain routing

### DIFF
--- a/inc/fastrpc_internal.h
+++ b/inc/fastrpc_internal.h
@@ -16,6 +16,7 @@
 #include "AEEQList.h"
 #include "AEEStdErr.h"
 #include "fastrpc_common.h"
+#include "fastrpc_ioctl.h"
 
 // Aligns the memory
 #define ALIGN_B(p, a)	      (((p) + ((a) - 1)) & ~((a) - 1))
@@ -450,6 +451,14 @@ static __inline int convert_kernel_to_user_error(int nErr, int err_no) {
 }
 
 /**
+  * @brief Get both secure and non-secure device names for a domain
+  * @param domain_id: Domain ID
+  * @param secure_name: Output pointer for secure device name
+  * @param non_secure_name: Output pointer for non-secure device name
+  **/
+void get_domain_device_names(int domain_id, const char **secure_name, const char **non_secure_name);
+
+/**
   * @brief utility APIs used in fastRPC library to get name, handle from domain 
   **/
 int get_domain_from_name(const char *uri, uint32_t type);
@@ -514,9 +523,5 @@ int ioctl_optimization(int dev, uint32_t max_concurrency);
  */
 int ioctl_mdctx_manage(int dev, int req, void *user_ctx,
 	unsigned int *domain_ids, unsigned int num_domain_ids, uint64_t *ctx);
-
-const char* get_secure_domain_name(int domain_id);
-
-#include "fastrpc_ioctl.h"
 
 #endif // FASTRPC_INTERNAL_H

--- a/inc/fastrpc_ioctl.h
+++ b/inc/fastrpc_ioctl.h
@@ -43,24 +43,6 @@
 
 #define FASTRPC_ATTR_NOVA (256)
 
-/* Secure and default device nodes */
-#if DEFAULT_DOMAIN_ID==ADSP_DOMAIN_ID
-	#define SECURE_DEVICE "/dev/fastrpc-adsp-secure"
-	#define DEFAULT_DEVICE "/dev/fastrpc-adsp"
-#elif DEFAULT_DOMAIN_ID==MDSP_DOMAIN_ID
-	#define SECURE_DEVICE "/dev/fastrpc-mdsp-secure"
-	#define DEFAULT_DEVICE "/dev/fastrpc-mdsp"
-#elif DEFAULT_DOMAIN_ID==SDSP_DOMAIN_ID
-	#define SECURE_DEVICE "/dev/fastrpc-sdsp-secure"
-	#define DEFAULT_DEVICE "/dev/fastrpc-sdsp"
-#elif DEFAULT_DOMAIN_ID==CDSP_DOMAIN_ID
-	#define SECURE_DEVICE "/dev/fastrpc-cdsp-secure"
-	#define DEFAULT_DEVICE "/dev/fastrpc-cdsp"
-#else
-	#define SECURE_DEVICE ""
-	#define DEFAULT_DEVICE ""
-#endif
-
 #define INITIALIZE_REMOTE_ARGS(total)	int *pfds = NULL; \
 					unsigned *pattrs = NULL; \
 					args = (struct fastrpc_invoke_args*) calloc(sizeof(*args), total);	\

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -33,20 +33,6 @@
 #define POLL_TIMEOUT	10 * 1000
 #define EVENT_SIZE		( sizeof (struct inotify_event) )
 #define EVENT_BUF_LEN	( 1024 * ( EVENT_SIZE + 16 ) )
-#define ADSP_SECURE_DEVICE_NAME "fastrpc-adsp-secure"
-#define SDSP_SECURE_DEVICE_NAME "fastrpc-sdsp-secure"
-#define MDSP_SECURE_DEVICE_NAME "fastrpc-mdsp-secure"
-#define CDSP_SECURE_DEVICE_NAME "fastrpc-cdsp-secure"
-#define CDSP1_SECURE_DEVICE_NAME "fastrpc-cdsp1-secure"
-#define GDSP0_SECURE_DEVICE_NAME "fastrpc-gdsp0-secure"
-#define GDSP1_SECURE_DEVICE_NAME "fastrpc-gdsp1-secure"
-#define ADSP_DEVICE_NAME "fastrpc-adsp"
-#define SDSP_DEVICE_NAME "fastrpc-sdsp"
-#define MDSP_DEVICE_NAME "fastrpc-mdsp"
-#define CDSP_DEVICE_NAME "fastrpc-cdsp"
-#define CDSP1_DEVICE_NAME "fastrpc-cdsp1"
-#define GDSP0_DEVICE_NAME "fastrpc-gdsp0"
-#define GDSP1_DEVICE_NAME "fastrpc-gdsp1"
 
 // Array of supported domain names and its corresponding ID's.
 static domain_t supported_domains[] = {{ADSP_DOMAIN_ID, ADSP_DOMAIN},
@@ -70,95 +56,23 @@ static domain_t *get_domain_uri(int domain_id) {
   return NULL;
 }
 
-static const char *get_secure_device_name(int domain_id) {
-	const char *name = NULL;
-	int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
-
-	switch (domain) {
-	case ADSP_DOMAIN_ID:
-		name = ADSP_SECURE_DEVICE_NAME;
-		break;
-	case SDSP_DOMAIN_ID:
-		name = SDSP_SECURE_DEVICE_NAME;
-		break;
-	case MDSP_DOMAIN_ID:
-		name = MDSP_SECURE_DEVICE_NAME;
-		break;
-	case CDSP_DOMAIN_ID:
-		name = CDSP_SECURE_DEVICE_NAME;
-		break;
-	case CDSP1_DOMAIN_ID:
-		name = CDSP1_SECURE_DEVICE_NAME;
-		break;
-	case GDSP0_DOMAIN_ID:
-		name = GDSP0_SECURE_DEVICE_NAME;
-		break;
-	case GDSP1_DOMAIN_ID:
-		name = GDSP1_SECURE_DEVICE_NAME;
-		break;
-	default:
-		FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
-		break;
-	}
-
-	return name;
-}
-
-static const char *get_non_secure_device_name(int domain_id) {
-	const char *name = NULL;
-	int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
-
-	switch (domain) {
-	case ADSP_DOMAIN_ID:
-		name = ADSP_DEVICE_NAME;
-		break;
-	case SDSP_DOMAIN_ID:
-		name = SDSP_DEVICE_NAME;
-		break;
-	case MDSP_DOMAIN_ID:
-		name = MDSP_DEVICE_NAME;
-		break;
-	case CDSP_DOMAIN_ID:
-		name = CDSP_DEVICE_NAME;
-		break;
-	case CDSP1_DOMAIN_ID:
-		name = CDSP1_DEVICE_NAME;
-		break;
-	case GDSP0_DOMAIN_ID:
-		name = GDSP0_DEVICE_NAME;
-		break;
-	case GDSP1_DOMAIN_ID:
-		name = GDSP1_DEVICE_NAME;
-		break;
-	default:
-		FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
-		break;
-	}
-
-	return name;
-}
 
 /**
  * fastrpc_dev_exists() - Check if device exists
- * @dev_name: Device name
+ * @dev_path: Full device path (e.g., "/dev/fastrpc-adsp")
  *
  * Return:
  *	True: Device node exists
  *	False: Device node does not exist
  */
-static bool fastrpc_dev_exists(const char* dev_name)
+static bool fastrpc_dev_exists(const char* dev_path)
 {
 	struct stat buffer;
-	char *path = NULL;
-	uint64_t len;
 
-	len = snprintf(0, 0, "/dev/%s", dev_name) + 1;
-	if(NULL == (path = (char *)malloc(len * sizeof(char))))
+	if (!dev_path)
 		return false;
 
-	snprintf(path, (int)len, "/dev/%s", dev_name);
-
-	return (stat(path, &buffer) == 0);
+	return (stat(dev_path, &buffer) == 0);
 }
 
 /**
@@ -175,8 +89,7 @@ static int fastrpc_wait_for_device(int domain)
 	const char *sec_dev_name = NULL, *non_sec_dev_name = NULL;
 	struct pollfd pfd[1];
 
-	sec_dev_name = get_secure_device_name(domain);
-	non_sec_dev_name = get_non_secure_device_name(domain);
+	get_domain_device_names(domain, &sec_dev_name, &non_sec_dev_name);
 
 	if (fastrpc_dev_exists(sec_dev_name) || fastrpc_dev_exists(non_sec_dev_name))
 		return 0;
@@ -227,11 +140,21 @@ static int fastrpc_wait_for_device(int domain)
 		 /* Loop over all events in the buffer. */
 		for (char *ptr = buffer; ptr < buffer + len;
 					ptr += sizeof(struct inotify_event) + event->len) {
+			const char *sec_dev_basename = NULL, *non_sec_dev_basename = NULL;
 			event = (struct inotify_event *) ptr;
+
+			/* Extract just the device name from full path for comparison */
+			sec_dev_basename = strrchr(sec_dev_name, '/');
+			non_sec_dev_basename = strrchr(non_sec_dev_name, '/');
+
+			/* Skip the '/' character if found */
+			sec_dev_basename++;
+			non_sec_dev_basename++;
+
 			/* Check if the event corresponds to the creation of the device node. */
 			if (event->wd == watch_fd && (event->mask & IN_CREATE) &&
-				((strcmp(sec_dev_name, event->name) == 0) ||
-				(strcmp(non_sec_dev_name, event->name) == 0))) {
+				((sec_dev_basename && strcmp(sec_dev_basename, event->name) == 0) ||
+				(non_sec_dev_basename && strcmp(non_sec_dev_basename, event->name) == 0))) {
 				/* Device node created, process proceed to open and use it. */
 				VERIFY_IPRINTF("Device node %s created!\n", event->name);
 				goto bail; /* Exit the loop after device creation is detected. */

--- a/src/adsp_default_listener.c
+++ b/src/adsp_default_listener.c
@@ -71,7 +71,7 @@ static domain_t *get_domain_uri(int domain_id) {
 }
 
 static const char *get_secure_device_name(int domain_id) {
-	const char *name;
+	const char *name = NULL;
 	int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
 
 	switch (domain) {
@@ -97,15 +97,15 @@ static const char *get_secure_device_name(int domain_id) {
 		name = GDSP1_SECURE_DEVICE_NAME;
 		break;
 	default:
-		name = DEFAULT_DEVICE;
+		FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
 		break;
 	}
 
 	return name;
 }
 
-static const char *get_default_device_name(int domain_id) {
-	const char *name;
+static const char *get_non_secure_device_name(int domain_id) {
+	const char *name = NULL;
 	int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
 
 	switch (domain) {
@@ -131,7 +131,7 @@ static const char *get_default_device_name(int domain_id) {
 		name = GDSP1_DEVICE_NAME;
 		break;
 	default:
-		name = DEFAULT_DEVICE;
+		FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
 		break;
 	}
 
@@ -172,13 +172,13 @@ static bool fastrpc_dev_exists(const char* dev_name)
 static int fastrpc_wait_for_device(int domain)
 {
 	int inotify_fd = -1, watch_fd = -1, err = 0;
-	const char *sec_dev_name = NULL, *def_dev_name = NULL;
+	const char *sec_dev_name = NULL, *non_sec_dev_name = NULL;
 	struct pollfd pfd[1];
 
 	sec_dev_name = get_secure_device_name(domain);
-	def_dev_name = get_default_device_name(domain);
+	non_sec_dev_name = get_non_secure_device_name(domain);
 
-	if (fastrpc_dev_exists(sec_dev_name) || fastrpc_dev_exists(def_dev_name))
+	if (fastrpc_dev_exists(sec_dev_name) || fastrpc_dev_exists(non_sec_dev_name))
 		return 0;
 
 	inotify_fd = inotify_init();
@@ -194,7 +194,7 @@ static int fastrpc_wait_for_device(int domain)
 		return AEE_EINVALIDFD;
 	}
 
-	if (fastrpc_dev_exists(sec_dev_name) || fastrpc_dev_exists(def_dev_name))
+	if (fastrpc_dev_exists(sec_dev_name) || fastrpc_dev_exists(non_sec_dev_name))
 		goto bail;
 
 	memset(pfd, 0 , sizeof(pfd));
@@ -231,7 +231,7 @@ static int fastrpc_wait_for_device(int domain)
 			/* Check if the event corresponds to the creation of the device node. */
 			if (event->wd == watch_fd && (event->mask & IN_CREATE) &&
 				((strcmp(sec_dev_name, event->name) == 0) ||
-				(strcmp(def_dev_name, event->name) == 0))) {
+				(strcmp(non_sec_dev_name, event->name) == 0))) {
 				/* Device node created, process proceed to open and use it. */
 				VERIFY_IPRINTF("Device node %s created!\n", event->name);
 				goto bail; /* Exit the loop after device creation is detected. */

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3038,7 +3038,7 @@ static void domain_deinit(int domain) {
 }
 
 static const char *get_domain_name(int domain_id) {
-  const char *name;
+  const char *name = NULL;
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
 
   switch (domain) {
@@ -3064,7 +3064,7 @@ static const char *get_domain_name(int domain_id) {
     name = GDSP1RPC_DEVICE;
     break;
   default:
-    name = DEFAULT_DEVICE;
+    FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
     break;
   }
   return name;
@@ -3075,40 +3075,7 @@ int open_device_node(int domain_id) {
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
   int sess_id = GET_SESSION_ID_FROM_DOMAIN_ID(domain_id);
 
-  switch (domain) {
-  case ADSP_DOMAIN_ID:
-  case SDSP_DOMAIN_ID:
-  case MDSP_DOMAIN_ID:
-    dev = open(get_secure_domain_name(domain), O_NONBLOCK);
-    if ((dev < 0) && (errno == ENOENT)) {
-      FARF(RUNTIME_RPC_HIGH,
-           "Device node %s open failed for domain %d (errno %s),"
-           "falling back to node %s \n",
-           get_secure_domain_name(domain), domain, strerror(errno),
-           get_domain_name(domain));
-      dev = open(get_domain_name(domain), O_NONBLOCK);
-      if ((dev < 0) && (errno == ENOENT)) {
-        FARF(RUNTIME_RPC_HIGH,
-             "Device node %s open failed for domain %d (errno %s),"
-             "falling back to node %s \n",
-             get_domain_name(domain), domain, strerror(errno), DEFAULT_DEVICE);
-        dev = open(DEFAULT_DEVICE, O_NONBLOCK);
-      }
-    } else if ((dev < 0) && (errno == EACCES)) {
-      // Open the default device node if unable to open the
-      // secure device node due to permissions
-      FARF(RUNTIME_RPC_HIGH,
-           "Device node %s open failed for domain %d (errno %s),"
-           "falling back to node %s \n",
-           get_secure_domain_name(domain), domain, strerror(errno),
-           DEFAULT_DEVICE);
-      dev = open(DEFAULT_DEVICE, O_NONBLOCK);
-    }
-    break;
-  case CDSP_DOMAIN_ID:
-  case CDSP1_DOMAIN_ID:
-  case GDSP0_DOMAIN_ID:
-  case GDSP1_DOMAIN_ID:
+  if (IS_VALID_DOMAIN_ID(domain)) {
     dev = open(get_secure_domain_name(domain), O_NONBLOCK);
     if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
       FARF(RUNTIME_RPC_HIGH,
@@ -3118,18 +3085,11 @@ int open_device_node(int domain_id) {
            get_domain_name(domain));
       dev = open(get_domain_name(domain), O_NONBLOCK);
       if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
-        // Open the default device node if actual device node
-        // is not present
         FARF(RUNTIME_RPC_HIGH,
-             "Device node %s open failed for domain %d (errno %s),"
-             "falling back to node %s \n",
-             get_domain_name(domain), domain, strerror(errno), DEFAULT_DEVICE);
-        dev = open(DEFAULT_DEVICE, O_NONBLOCK);
+             "Device node %s open failed for domain %d (errno %s)\n",
+             get_domain_name(domain), domain, strerror(errno));
       }
     }
-    break;
-  default:
-    break;
   }
   if (dev < 0)
     FARF(ERROR,

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3037,58 +3037,61 @@ static void domain_deinit(int domain) {
   pthread_mutex_unlock(&hlist[domain].mut);
 }
 
-static const char *get_domain_name(int domain_id) {
-  const char *name = NULL;
+void get_domain_device_names(int domain_id, const char **secure_name, const char **non_secure_name) {
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
 
   switch (domain) {
   case ADSP_DOMAIN_ID:
-    name = ADSPRPC_DEVICE;
+    *secure_name = ADSPRPC_SECURE_DEVICE;
+    *non_secure_name = ADSPRPC_DEVICE;
     break;
   case SDSP_DOMAIN_ID:
-    name = SDSPRPC_DEVICE;
+    *secure_name = SDSPRPC_SECURE_DEVICE;
+    *non_secure_name = SDSPRPC_DEVICE;
     break;
   case MDSP_DOMAIN_ID:
-    name = MDSPRPC_DEVICE;
+    *secure_name = MDSPRPC_SECURE_DEVICE;
+    *non_secure_name = MDSPRPC_DEVICE;
     break;
   case CDSP_DOMAIN_ID:
-    name = CDSPRPC_DEVICE;
+    *secure_name = CDSPRPC_SECURE_DEVICE;
+    *non_secure_name = CDSPRPC_DEVICE;
     break;
   case CDSP1_DOMAIN_ID:
-    name = CDSP1RPC_DEVICE;
+    *secure_name = CDSP1RPC_SECURE_DEVICE;
+    *non_secure_name = CDSP1RPC_DEVICE;
     break;
   case GDSP0_DOMAIN_ID:
-    name = GDSP0RPC_DEVICE;
+    *secure_name = GDSP0RPC_SECURE_DEVICE;
+    *non_secure_name = GDSP0RPC_DEVICE;
     break;
   case GDSP1_DOMAIN_ID:
-    name = GDSP1RPC_DEVICE;
+    *secure_name = GDSP1RPC_SECURE_DEVICE;
+    *non_secure_name = GDSP1RPC_DEVICE;
     break;
   default:
     FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
+    *secure_name = NULL;
+    *non_secure_name = NULL;
     break;
   }
-  return name;
 }
 
 int open_device_node(int domain_id) {
   int dev = -1, nErr = 0;
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
   int sess_id = GET_SESSION_ID_FROM_DOMAIN_ID(domain_id);
+  const char *secure_dev = NULL, *non_secure_dev = NULL;
 
   if (IS_VALID_DOMAIN_ID(domain)) {
-    dev = open(get_secure_domain_name(domain), O_NONBLOCK);
+    get_domain_device_names(domain, &secure_dev, &non_secure_dev);
+    dev = open(secure_dev, O_NONBLOCK);
     if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
       FARF(RUNTIME_RPC_HIGH,
            "Device node %s open failed for domain %d (errno %s),"
            "falling back to node %s \n",
-           get_secure_domain_name(domain), domain, strerror(errno),
-           get_domain_name(domain));
-      dev = open(get_domain_name(domain), O_NONBLOCK);
-      if ((dev < 0) && ((errno == ENOENT) || (errno == EACCES))) {
-        FARF(RUNTIME_RPC_HIGH,
-             "Device node %s open failed for domain %d (errno %s)\n",
-             get_domain_name(domain), domain, strerror(errno));
-      }
+           secure_dev, domain, strerror(errno), non_secure_dev);
+      dev = open(non_secure_dev, O_NONBLOCK);
     }
   }
   if (dev < 0)
@@ -3097,8 +3100,8 @@ int open_device_node(int domain_id) {
          "dev : %s. (errno %d, %s) (Either the remote processor is down, or "
          "application does not have permission to access the remote "
          "processor\n",
-         nErr, __func__, domain_id, sess_id, get_secure_domain_name(domain),
-         get_domain_name(domain), errno, strerror(errno));
+         nErr, __func__, domain_id, sess_id, secure_dev,
+         non_secure_dev, errno, strerror(errno));
   return dev;
 }
 

--- a/src/fastrpc_ioctl.c
+++ b/src/fastrpc_ioctl.c
@@ -10,42 +10,6 @@
 #include "remote.h"
 #include <sys/ioctl.h>
 
-/* Returns the name of the domain based on the following
- ADSP/SLPI/MDSP/CDSP - Return Secure node
- */
-const char *get_secure_domain_name(int domain_id) {
-  const char *name = NULL;
-  int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
-
-  switch (domain) {
-  case ADSP_DOMAIN_ID:
-    name = ADSPRPC_SECURE_DEVICE;
-    break;
-  case SDSP_DOMAIN_ID:
-    name = SDSPRPC_SECURE_DEVICE;
-    break;
-  case MDSP_DOMAIN_ID:
-    name = MDSPRPC_SECURE_DEVICE;
-    break;
-  case CDSP_DOMAIN_ID:
-    name = CDSPRPC_SECURE_DEVICE;
-    break;
-  case CDSP1_DOMAIN_ID:
-    name = CDSP1RPC_SECURE_DEVICE;
-    break;
-  case GDSP0_DOMAIN_ID:
-    name = GDSP0RPC_SECURE_DEVICE;
-    break;
-  case GDSP1_DOMAIN_ID:
-    name = GDSP1RPC_SECURE_DEVICE;
-    break;
-  default:
-    FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
-    break;
-  }
-  return name;
-}
-
 int ioctl_init(int dev, uint32_t flags, int attr, unsigned char *shell, int shelllen,
                int shellfd, char *mem, int memlen, int memfd, int tessiglen) {
   int ioErr = 0;

--- a/src/fastrpc_ioctl.c
+++ b/src/fastrpc_ioctl.c
@@ -14,7 +14,7 @@
  ADSP/SLPI/MDSP/CDSP - Return Secure node
  */
 const char *get_secure_domain_name(int domain_id) {
-  const char *name;
+  const char *name = NULL;
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain_id);
 
   switch (domain) {
@@ -40,7 +40,7 @@ const char *get_secure_domain_name(int domain_id) {
     name = GDSP1RPC_SECURE_DEVICE;
     break;
   default:
-    name = DEFAULT_DEVICE;
+    FARF(ERROR, "ERROR: %s Invalid domain %d", __func__, domain);
     break;
   }
   return name;


### PR DESCRIPTION
Remove legacy DEFAULT_DEVICE fallback that could cause incorrect domain routing. Previously, if a requested domain's device nodes were unavailable, the code would fall back to the DEFAULT_DEVICE of the linked library (e.g., ADSP for libadsprpc.so), ignoring the user's domain request.

Now each domain only attempts: secure node -> non-secure node, and fails cleanly if both are unavailable. This ensures device opening respects the user's requested domain.

Consolidate all domain cases (ADSP/MDSP/SDSP/CDSP/GDSP) into unified logic and improve error handling.

Additionally, merge domain device name functions into a unified API by replacing separate get_secure_domain_name() and get_non_secure_domain_name() implementations with a single get_domain_device_names() function that returns both names in one call.

Supersedes #210 due to outdated and stale changes.
Fixes: #164 