### PR TITLE
Qualcomm Preflight Checks: Replace pull_request_target with pull_request

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -1,6 +1,6 @@
 name: Qualcomm Preflight Checks
 on:
-  pull_request_target:
+  pull_request:
     branches: [ development ]
   push:
     branches: [ development ]


### PR DESCRIPTION
### Summary
Update Qualcomm Preflight Checks GitHub Actions workflow to use
`pull_request` instead of `pull_request_target`.

This change is required to address a reported GitHub Actions
vulnerability and to restore correct behavior for fork-based PRs.

---

### Why this change is needed
* `pull_request_target` bypasses fork PR approval protections
* Can expose repository secrets or write privileges
* Violates current GitHub Actions security best practices
* Causes ABI checks and other QCOM preflight checks to be skipped for forked PRs due to event behavior

Switching to `pull_request`:
* Restores ABI checks for fork-based PRs
* Ensures workflows run with least privilege
* Aligns with Qualcomm security guidance and recent incident reviews

---

### Impact
* No change for internal PRs
* Forked PRs will now correctly trigger ABI checks
* Improves overall CI security posture

---

### References
* GitHub Actions security advisory on `pull_request_target`
* Qualcomm IT Security communication from Mark Matyas