### PR TITLE
files: Fix service startup race condition with udev rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ AM_PROG_CC_C_O
 
 # Checks for libraries.
 
+# Enable pkg-config
+PKG_PROG_PKG_CONFIG
+
 # Configure systemd unit directory option (--with-systemdsystemunitdir)
 AC_ARG_WITH([systemdsystemunitdir],
   [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
@@ -48,12 +51,23 @@ AC_ARG_WITH([systemdsystemunitdir],
 AC_MSG_NOTICE([systemd unit directory: $systemdsystemunitdir])
 AC_SUBST([systemdsystemunitdir])
 
+# Configure udev rules directory using pkg-config
+AC_ARG_WITH([udevrulesdir],
+  [AS_HELP_STRING([--with-udevrulesdir=DIR],
+                  [Directory for udev rules files])],
+  [udevrulesdir="$withval"],
+  [
+    # Get udev directory from pkg-config
+    PKG_CHECK_VAR([udevrulesdir], [udev], [udevdir],
+      [udevrulesdir="${udevrulesdir}/rules.d"],
+      [AC_MSG_ERROR([Could not determine udev rules directory. Please install udev development files or use --with-udevrulesdir=DIR])])
+  ])
+AC_MSG_NOTICE([udev rules directory: $udevrulesdir])
+AC_SUBST([udevrulesdir])
+
 # Checks for typedefs, structures, and compiler characteristics.
 
 # Checks for library functions.
-
-# Enable pkg-config
-PKG_PROG_PKG_CONFIG
 
 # Check for libyaml only if not Android
 AS_IF([test "$compile_for_android" = no], [

--- a/files/71-fastrpc.rules
+++ b/files/71-fastrpc.rules
@@ -1,0 +1,28 @@
+# udev rules for Qualcomm FastRPC devices
+# These rules set permissions and systemd tags for FastRPC device nodes
+
+# aDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd_audiopd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-adsp-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="adsprpcd_audiopd.service"
+
+# cDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsprpcd.service"
+
+# cDSP1 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp1", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsp1rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-cdsp1-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cdsp1rpcd.service"
+
+# gDSP0 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp0", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp0rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp0-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp0rpcd.service"
+
+# gDSP1 devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp1", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp1rpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-gdsp1-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="gdsp1rpcd.service"
+
+# sDSP devices
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-sdsp", GROUP="render", MODE="0666", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sdsprpcd.service"
+ACTION=="add", SUBSYSTEM=="misc", KERNEL=="fastrpc-sdsp-secure", TAG+="systemd", ENV{SYSTEMD_WANTS}+="sdsprpcd.service"

--- a/files/Makefile.am
+++ b/files/Makefile.am
@@ -12,3 +12,12 @@ dist_systemdsystemunit_DATA = \
 	gdsp0rpcd.service \
 	gdsp1rpcd.service \
 	sdsprpcd.service
+
+# udev rules
+
+# Define udev rules directory
+udevrulesdir = @udevrulesdir@
+
+# List of udev rules files to install
+dist_udevrules_DATA = \
+	71-fastrpc.rules

--- a/files/adsprpcd.service
+++ b/files/adsprpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/adsprpcd
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/adsprpcd_audiopd.service
+++ b/files/adsprpcd_audiopd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/adsprpcd audiopd
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/cdsp1rpcd.service
+++ b/files/cdsp1rpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/cdsprpcd rootpd cdsp1
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/cdsprpcd.service
+++ b/files/cdsprpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/cdsprpcd
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/gdsp0rpcd.service
+++ b/files/gdsp0rpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/gdsprpcd rootpd gdsp0
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/gdsp1rpcd.service
+++ b/files/gdsp1rpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/gdsprpcd rootpd gdsp1
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target

--- a/files/sdsprpcd.service
+++ b/files/sdsprpcd.service
@@ -9,6 +9,3 @@ Type=exec
 ExecStart=/usr/bin/sdsprpcd
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
The After= clause has no effect on the race between WantedBy=multi-user.target and kernel module loading. If multi-user.target is reached before the kernel module loads, the daemon will never start.

Fix by using ENV{SYSTEMD_WANTS} in udev rules to trigger services when FastRPC devices are detected.

Changes:
- Add 71-fastrpc.rules with device-triggered service startup
- Remove [Install] sections from all service files
- Update configure.ac to use pkg-config to query udevdir variable
- Update files/Makefile.am to install udev rules

Services now start only when device nodes are created, eliminating the race condition.

Fixes: #309 