### PR TITLE
CI : workflow_fix to align preflight checks with reusable workflow v2 spec.

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -22,5 +22,3 @@ jobs:
         enable-dependency-review: true         # default: true
         enable-armor-checkers: true
         armor-checker-options: '{"build-script":"ci/build.sh","runs-on":{"group":"GHA-fastrpc-Prd-SelfHosted-RG","labels":["self-hosted","fastrpc-prd-u2404-x64-large-od-ephem"]}}'
-    secrets:
-      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
The reusable workflow (qcom-reusable-workflows v2) does not define SEMGREP_APP_TOKEN in its secrets specification causing workflow validation to fail. Removed the secrets section as it's no longer required by the reusable workflow.

Resolves: "Invalid secret, SEMGREP_APP_TOKEN is not defined in the referenced workflow" error.