### PR TITLE
Enhance logging for expected DSP module-unavailable errors

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1488,11 +1488,19 @@ bail:
     }
     if (0 == check_rpc_error(nErr)) {
       if (get_logger_state(domain)) {
-        FARF(ERROR,
-             "Error 0x%x: %s failed for module %s, handle 0x%" PRIx64
-             ", method %d on domain %d (sc 0x%x) (errno %s)\n",
-             nErr, __func__, h->name, local, REMOTE_SCALARS_METHOD(sc), domain, sc,
-             strerror(errno));
+        if (nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
+          FARF(ALWAYS,
+               "Warning: %s module %s is not supported on DSP domain %d, handle 0x%" PRIx64
+               ", method %d (sc 0x%x) (errno %s)\n",
+               __func__, h->name, domain, local, REMOTE_SCALARS_METHOD(sc), sc,
+               strerror(errno));
+        } else {
+          FARF(ERROR,
+               "Error 0x%x: %s failed for module %s, handle 0x%" PRIx64
+               ", method %d on domain %d (sc 0x%x) (errno %s)\n",
+               nErr, __func__, h->name, local, REMOTE_SCALARS_METHOD(sc), domain, sc,
+               strerror(errno));
+        }
       }
     }
   }

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -349,8 +349,9 @@ static void *listener_start_thread(void *arg) {
     nErr = __QAIC_HEADER(adsp_listener1_init2)(adsp_listener1_handle);
     if ((nErr == DSP_AEE_EOFFSET + AEE_ERPC) ||
         nErr == DSP_AEE_EOFFSET + AEE_ENOSUCHMOD) {
-      FARF(ERROR, "Error 0x%x: %s domains support not available in listener",
-           nErr, __func__);
+      FARF(ALWAYS,
+           "Warning: %s domain support is unavailable on DSP in listener",
+           __func__);
       fastrpc_update_module_list(DOMAIN_LIST_DEQUEUE, domain, _const_adsp_listener1_handle, NULL, NULL);
       adsp_listener1_handle = INVALID_HANDLE;
       VERIFY(AEE_SUCCESS == (nErr = __QAIC_HEADER(adsp_listener_init2)()));


### PR DESCRIPTION
Handle AEE_ENOSUCHMOD as an expected module-availability conditions by logging them at FARF(ALWAYS) with a "Warning:" prefix instead of FARF(ERROR) in fastrpc_apps_user.c and listener_android.c. This reduces unnecessary error-noise while preserving ERROR logs for unexpected failures.

Fixes: #297 