### PR TITLE
Add support for rpcmem_alloc2 

### DIFF
--- a/src/rpcmem_linux.c
+++ b/src/rpcmem_linux.c
@@ -240,6 +240,10 @@ void *rpcmem_alloc(int heapid, uint32_t flags, int size) {
   return rpcmem_alloc_internal(heapid, flags, size);
 }
 
+void *rpcmem_alloc2(int heapid, uint32_t flags, size_t size) {
+  return rpcmem_alloc_internal(heapid, flags, (size_t)size);
+}
+
 void rpcmem_deinit_internal() { rpcmem_deinit(); }
 
 void rpcmem_init_internal() { rpcmem_init(); }


### PR DESCRIPTION
## Support for Large Shared Memory Allocations

This PR introduces a new API:

- `rpcmem_alloc2`

The new API supports shared memory allocations **≥ 2GB**.

The existing `rpcmem_alloc` API uses an `int`-sized length parameter, which can overflow or fail for large allocations.  
`rpcmem_alloc2` avoids signed size limitations and safely supports large buffer requests.