### PR TITLE
Build per-domain DSP search path cache with ARCH_VER

### DIFF
--- a/Docs/conf_guideline.md
+++ b/Docs/conf_guideline.md
@@ -16,46 +16,52 @@ The YAML configuration file enables **fastrpc** to set machine-specific configur
   (fastrpc uses same path for matching machine names)
 ---
 ### 📄 **Current Properties**
-- **DSP_LIBRARY_PATH**: Specifies the path to DSP binaries and resources for the Machine.
+- **DSP_LIBRARY_PATH**: Specifies the path to DSP binaries and resources for the Machine. Path is relative to `/usr/share/qcom/`.
+- **ADSP_ARCH / MDSP_ARCH / SDSP_ARCH / CDSP_ARCH** *(optional)*:
+  Specifies the Hexagon architecture version for the corresponding DSP domain. Used as a fallback on
+  legacy targets where the `ARCH_VER` kernel capability is not supported. Value must match `v[0-9a-f]+`
+  (e.g. `v60`, `v65`, `v66`). Only the domain(s) present on the target need to be specified.
 ---
 
 ### 📁 **Format Guidelines**
-The configuration uses YAML format with the following structure:
+Each machine has its own `.yaml` file under the configuration directory:
 ```
 machines:
-  "Machine Name":
-    DSP_LIBRARY_PATH: "/relative/path/to/dsp/binaries/"
+  Machine Name:
+    DSP_LIBRARY_PATH: relative/path/to/dsp/binaries
+    CDSP_ARCH: v60   # optional, for legacy targets
 ```
 
 **Key Points:**
 - The root element is `machines:`
-- Each machine name is a quoted string key under `machines:`
+- Machine name is an unquoted key under `machines:`
 - Properties are indented under each machine name
 - Use proper YAML indentation
-- Paths should be quoted strings
+- `DSP_LIBRARY_PATH` is a relative path (relative to `/usr/share/qcom/`), unquoted, no leading slash
+- Avoid tabs (use spaces only)
 
 ---
 
 ### ✅ **Example Configuration**
 ```
 machines:
-  "Qualcomm Technologies, Inc. DB820c":
-    DSP_LIBRARY_PATH: "/apq8096/Qualcomm/db820c/"
-  "Thundercomm Dragonboard 845c":
-    DSP_LIBRARY_PATH: "/sdm845/Thundercomm/db845c/"
+  Qualcomm Technologies, Inc. DB820c:
+    DSP_LIBRARY_PATH: apq8096/Qualcomm/db820c/dsp
+    ADSP_ARCH: v60
 ```
+
 
 ---
 
 ### ⚠️ **Important Notes**
 - Do **not** modify machine names unless adding a new supported Machine.
 - Ensure `DSP_LIBRARY_PATH` values:
-  - Are enclosed in double quotes (`"..."`).
-  - Are **relative to `/usr/share/qcom/`**.
+  - Are **relative to `/usr/share/qcom/`** with no leading slash.
+  - Are unquoted.
+- Ensure `*_ARCH` values match the pattern `v[0-9a-f]+` (e.g. `v60`, `v65`, `v66`).
 - Follow YAML syntax rules:
   - Use consistent indentation.
   - Ensure proper spacing after colons (`: `).
-  - Quote strings containing special characters or spaces.
   - Avoid tabs (use spaces only).
 - Maintain:
   - Proper YAML structure and hierarchy.
@@ -69,11 +75,13 @@ machines:
 ---
 
 ### ➕ **Adding New Platforms**
-To add a new Machine, follow the existing YAML format:
+Create a new file under the configuration directory:
 ```
 machines:
-  "New Machine Name":
-    DSP_LIBRARY_PATH: "/new_machine/path/"
+  New Machine Name:
+    DSP_LIBRARY_PATH: new_machine/path/dsp
+    ADSP_ARCH: v<XY>   # optional, for legacy targets
+    CDSP_ARCH: v<XY>   # optional, for legacy targets
 ```
 
 Ensure the new entry is properly indented under the `machines:` root element and follows YAML syntax conventions.

--- a/Docs/schemas/fastrpc-config-schema.yaml
+++ b/Docs/schemas/fastrpc-config-schema.yaml
@@ -1,1 +1,7 @@
-machines: map(key=str(), value=map(DSP_LIBRARY_PATH=regex('^/.+/')))
+machines: >
+  map(key=str(), value=map(
+    DSP_LIBRARY_PATH=regex('^[^/].+'),
+    ADSP_ARCH=regex('^v[0-9a-f]+$', required=False),
+    MDSP_ARCH=regex('^v[0-9a-f]+$', required=False),
+    SDSP_ARCH=regex('^v[0-9a-f]+$', required=False),
+    CDSP_ARCH=regex('^v[0-9a-f]+$', required=False)))

--- a/inc/fastrpc_config_parser.h
+++ b/inc/fastrpc_config_parser.h
@@ -4,14 +4,24 @@
 #ifndef FASTRPC_YAML_PARSER_H
 #define FASTRPC_YAML_PARSER_H
 
+#include "fastrpc_common.h"
+
 // DEFAULT_DSP_SEARCH_PATHS intentionally left empty - these paths should be provided through configuration files
 #ifndef DEFAULT_DSP_SEARCH_PATHS
 #define DEFAULT_DSP_SEARCH_PATHS ""
 #endif
 #define DSP_LIB_KEY "DSP_LIBRARY_PATH"
 
+/*
+ * Per-domain YAML keys for the Hexagon architecture version string (e.g. "v65").
+ * Only legacy domains (ADSP=0, MDSP=1, SDSP=2, CDSP=3) are supported;
+ * newer domains use the ARCH_VER capability instead.
+ */
+extern const char *DSP_ARCH_KEY[NUM_DOMAINS];
+
 extern char DSP_LIBS_LOCATION[PATH_MAX];
 
 void configure_dsp_paths();
+const char *get_dsp_arch_from_yaml(int domain);
 
 #endif /*FASTRPC_YAML_PARSER_H*/

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -77,8 +77,10 @@
 
 #define VENDOR_DSP_LOCATION "/vendor/dsp/"
 #define VENDOR_DOM_LOCATION "/vendor/dsp/xdsp/"
+#define HEXAGON_LIBS_PATH_PREFIX CONFIG_BASE_DIR "hexagon"
 
 char DSP_LIBS_LOCATION[PATH_MAX] = DEFAULT_DSP_SEARCH_PATHS;
+static char DSP_SEARCH_PATHS_CACHE[NUM_DOMAINS][PATH_MAX] = {{0}};
 
 #ifdef LE_ENABLE
 #define PROPERTY_VALUE_MAX                                                     \
@@ -326,6 +328,92 @@ extern void apps_mem_table_deinit(void);
 
 static uint32_t crc_table[256];
 static atomic_bool timer_expired = false;
+
+static void build_dsp_search_path_cache_for_domain(int domain) {
+  int nErr = AEE_SUCCESS;
+  fastrpc_capability cap = {0, ARCH_VER, 0};
+  char arch_str[64] = {0};
+  char arch_path[PATH_MAX] = {0};
+  char *domain_path_cache = NULL;
+  const char *yaml_arch = NULL;
+
+  if (!IS_VALID_DOMAIN_ID(domain)) {
+    FARF(ALWAYS, "Warning: %s: Invalid domain %d", __func__, domain);
+    return;
+  }
+
+  domain_path_cache = DSP_SEARCH_PATHS_CACHE[domain];
+
+  /*
+   * Resolve arch string: capability API is preferred; YAML is the fallback
+   * for legacy targets where the capability is not supported.
+   */
+  cap.domain = domain;
+  nErr = fastrpc_get_cap(cap.domain, cap.attribute_ID, &cap.capability);
+  if (nErr == AEE_SUCCESS && cap.capability != 0) {
+    snprintf(arch_str, sizeof(arch_str), "v%02x", cap.capability & 0xFF);
+    FARF(RUNTIME_RPC_HIGH, "%s: domain %d: resolved ARCH from capability 0x%x: %s",
+         __func__, domain, cap.capability, arch_str);
+  } else {
+    /* Legacy target: capability API not supported, use YAML ARCH config. */
+    FARF(ALWAYS,
+         "Warning 0x%x: %s: ARCH_VER capability not supported for domain %d, "
+         "trying YAML ARCH config",
+         nErr, __func__, domain);
+    yaml_arch = get_dsp_arch_from_yaml(domain);
+    if (!yaml_arch || yaml_arch[0] == '\0') {
+      FARF(ALWAYS,
+           "Warning: %s: No YAML ARCH config for domain %d, "
+           "using DSP_LIBS_LOCATION only",
+           __func__, domain);
+      strlcpy(domain_path_cache, DSP_LIBS_LOCATION, PATH_MAX);
+      return;
+    }
+    strlcpy(arch_str, yaml_arch, sizeof(arch_str));
+    FARF(RUNTIME_RPC_HIGH, "%s: domain %d: resolved ARCH from YAML config: %s",
+         __func__, domain, arch_str);
+  }
+
+  /*
+   * Build the arch-specific path and put it at the front of the search list,
+   * followed by DSP_LIBS_LOCATION (board/YAML paths + generic fallback).
+   * The user-set ADSP_LIBRARY_PATH env is prepended at open-time by
+   * apps_std_imp, so the effective resolution order is:
+   *   1. ADSP_LIBRARY_PATH (user/container, highest priority)
+   *   2. arch-specific path  (e.g. CONFIG_BASE_DIR/hexagon/v75)
+   *   3. DSP_LIBS_LOCATION   (board-specific path from YAML + generic fallback)
+   */
+  if (snprintf(arch_path, sizeof(arch_path), "%s/%s",
+               HEXAGON_LIBS_PATH_PREFIX, arch_str) >= (int)sizeof(arch_path)) {
+    FARF(ALWAYS,
+         "Warning: %s: ARCH path truncated for domain %d, "
+         "using DSP_LIBS_LOCATION only",
+         __func__, domain);
+    strlcpy(domain_path_cache, DSP_LIBS_LOCATION, PATH_MAX);
+    return;
+  }
+
+  strlcpy(domain_path_cache, arch_path, PATH_MAX);
+  strlcat(domain_path_cache, ";", PATH_MAX);
+  if (strlcat(domain_path_cache, DSP_LIBS_LOCATION, PATH_MAX) >= PATH_MAX) {
+    FARF(ALWAYS,
+         "Warning: %s: Failed to build search list for domain %d, "
+         "using DSP_LIBS_LOCATION only",
+         __func__, domain);
+    strlcpy(domain_path_cache, DSP_LIBS_LOCATION, PATH_MAX);
+    return;
+  }
+
+  FARF(RUNTIME_RPC_HIGH, "%s: domain %d: search path: %s", __func__, domain,
+       domain_path_cache);
+}
+
+static const char *get_dsp_search_path_for_domain(int domain) {
+  if (IS_VALID_DOMAIN_ID(domain) && DSP_SEARCH_PATHS_CACHE[domain][0] != '\0')
+    return DSP_SEARCH_PATHS_CACHE[domain];
+
+  return DSP_LIBS_LOCATION;
+}
 
 void set_thread_context(int domain) {
   if (tlsKey != INVALID_KEY) {
@@ -3792,6 +3880,7 @@ static int domain_init(int domain, int *dev) {
     }
   }
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_enable_kernel_optimizations(domain)));
+  build_dsp_search_path_cache_for_domain(domain);
   initFileWatcher(domain); // Ignore errors
   trace_marker_init(domain);
 
@@ -3927,7 +4016,8 @@ static void exit_thread(void *value) {
 }
 
 const char* get_dsp_search_path() {
-  return DSP_LIBS_LOCATION;
+  int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(get_current_domain());
+  return get_dsp_search_path_for_domain(domain);
 }
 
 /*

--- a/src/fastrpc_config_parser.c
+++ b/src/fastrpc_config_parser.c
@@ -41,6 +41,28 @@
 #include "HAP_farf.h"
 #include "apps_std_internal.h"
 #include "fastrpc_config_parser.h"
+#include "fastrpc_internal.h"
+
+const char *DSP_ARCH_KEY[NUM_DOMAINS] = {
+  "ADSP_ARCH",
+  "MDSP_ARCH",
+  "SDSP_ARCH",
+  "CDSP_ARCH",
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+};
+
+static char DSP_ARCH_FROM_YAML[NUM_DOMAINS][8] = {{0}};
+
+const char *get_dsp_arch_from_yaml(int domain) {
+  if (!IS_VALID_DOMAIN_ID(domain))
+    return NULL;
+  if (DSP_ARCH_FROM_YAML[domain][0] == '\0')
+    return NULL;
+  return DSP_ARCH_FROM_YAML[domain];
+}
 
 static int compare_strings(const void *a, const void *b) {
   return strcmp(*(const char **)a, *(const char **)b);
@@ -90,9 +112,25 @@ static void get_dsp_lib_path(const char *machine_name, const char *filepath, cha
           yaml_event_delete(&event);
           if (yaml_parser_parse(&parser, &event) && event.type == YAML_SCALAR_EVENT) {
             strlcpy(dsp_lib_paths, (const char *)event.data.scalar.value, PATH_MAX);
-			FARF(ALWAYS, "dsp_lib_paths is %s", dsp_lib_paths);
+            FARF(ALWAYS, "dsp_lib_paths is %s", dsp_lib_paths);
             found_dsp_path = 1;
-            done = 1;
+          }
+        } else if (in_target_machine) {
+          /* Check if this scalar is one of the per-domain ARCH keys */
+          int d;
+          for (d = 0; d < NUM_DOMAINS; d++) {
+            if (DSP_ARCH_KEY[d] && strcmp(value, DSP_ARCH_KEY[d]) == 0) {
+              yaml_event_delete(&event);
+              if (yaml_parser_parse(&parser, &event) &&
+                  event.type == YAML_SCALAR_EVENT) {
+                strlcpy(DSP_ARCH_FROM_YAML[d],
+                        (const char *)event.data.scalar.value,
+                        sizeof(DSP_ARCH_FROM_YAML[d]));
+                FARF(ALWAYS, "%s: YAML arch for domain %d (%s): %s",
+                     __func__, d, DSP_ARCH_KEY[d], DSP_ARCH_FROM_YAML[d]);
+              }
+              break;
+            }
           }
         }
         break;
@@ -101,9 +139,7 @@ static void get_dsp_lib_path(const char *machine_name, const char *filepath, cha
         if (in_target_machine) {
           // Exiting the target machine mapping
           in_target_machine = 0;
-          if (found_dsp_path) {
-            done = 1;
-          }
+          done = 1;
         }
         break;
       case YAML_STREAM_END_EVENT:


### PR DESCRIPTION
Replace the global DSP_LIBS_LOCATION in get_dsp_search_path() with a per-domain DSP_SEARCH_PATHS_CACHE[], built lazily in domain_init().

Search path preference order for each domain:
  1. ADSP_LIBRARY_PATH env (user/container, prepended at open-time)
  2. Arch-specific path (CONFIG_BASE_DIR/hexagon/v\<XY>)
     - Resolved via fastrpc_get_cap(ARCH_VER) low byte on modern targets
     - Falls back to per-domain YAML key (ADSP_ARCH..CDSP_ARCH) on legacy targets where the capability API is not supported
  3. DSP_LIBS_LOCATION (board-specific YAML path + generic fallback)

Add optional *_ARCH keys to the config schema and parse them into DSP_ARCH_FROM_YAML[] in fastrpc_config_parser.c, exposed via get_dsp_arch_from_yaml().

Update conf_guideline.md to document the new *_ARCH keys, relative path convention, per-file layout, and updated naming scheme.

CRs-Fixed: 4608348