### PR TITLE
Build warnings fixes

### DIFF
--- a/.github/workflows/build_linux_gnu.yml
+++ b/.github/workflows/build_linux_gnu.yml
@@ -31,5 +31,5 @@ jobs:
 
     - name: Compile code for LE platform
       run: |
-        GITCOMPILE_NO_MAKE=true ./gitcompile
-        make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-systemdsystemunitdir='lib/systemd/system'"
+        GITCOMPILE_NO_MAKE=true ./gitcompile --enable-stricter
+        make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-systemdsystemunitdir='lib/systemd/system' --enable-stricter"

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,79 @@ AC_ARG_WITH([config-base-dir],
 AC_MSG_NOTICE([Config base path: $config_base_dir])
 AC_SUBST([CONFIG_BASE_DIR], ["$config_base_dir"])
 
+# Enable stricter compiler flags
+# These are based on Debian's dpkg-buildflags defaults for compatibility with
+# distro builds and to catch issues during development
+AC_ARG_ENABLE([stricter],
+  [AS_HELP_STRING([--enable-stricter],
+                  [Enable stricter compiler flags (warnings, stack protection, fortify source, RELRO)])],
+  [enable_stricter=$enableval],
+  [enable_stricter=no])
+
+# Helper macro to test if compiler accepts a flag
+AC_DEFUN([CC_CHECK_FLAG], [
+  AC_MSG_CHECKING([if $CC supports $1])
+  saved_CFLAGS="$CFLAGS"
+  CFLAGS="$CFLAGS $1"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+    [AC_MSG_RESULT([yes]); $2],
+    [AC_MSG_RESULT([no]); $3])
+  CFLAGS="$saved_CFLAGS"
+])
+
+# Helper macro to test if linker accepts a flag
+AC_DEFUN([LD_CHECK_FLAG], [
+  AC_MSG_CHECKING([if linker supports $1])
+  saved_LDFLAGS="$LDFLAGS"
+  LDFLAGS="$LDFLAGS $1"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([])],
+    [AC_MSG_RESULT([yes]); $2],
+    [AC_MSG_RESULT([no]); $3])
+  LDFLAGS="$saved_LDFLAGS"
+])
+
+# Set up hardening flags
+STRICTER_CFLAGS=""
+STRICTER_CPPFLAGS=""
+STRICTER_LDFLAGS=""
+AS_IF([test "x$enable_stricter" = "xyes"], [
+  # Format string security warnings
+  STRICTER_CFLAGS="-Wformat -Werror=format-security -Werror=implicit-function-declaration"
+  
+  # Stack protection
+  CC_CHECK_FLAG([-fstack-protector-strong],
+    [STRICTER_CFLAGS="$STRICTER_CFLAGS -fstack-protector-strong"])
+  CC_CHECK_FLAG([-fstack-clash-protection],
+    [STRICTER_CFLAGS="$STRICTER_CFLAGS -fstack-clash-protection"])
+  
+  # Architecture-specific hardening
+  AS_CASE([$host_cpu],
+    [aarch64], [
+      CC_CHECK_FLAG([-mbranch-protection=standard],
+        [STRICTER_CFLAGS="$STRICTER_CFLAGS -mbranch-protection=standard"])
+    ],
+    []
+  )
+  
+  # FORTIFY_SOURCE and reproducible builds
+  STRICTER_CPPFLAGS="-D_FORTIFY_SOURCE=2 -Wdate-time"
+  
+  # RELRO - read-only relocations
+  LD_CHECK_FLAG([-Wl,-z,relro],
+    [STRICTER_LDFLAGS="-Wl,-z,relro"])
+  
+  AC_MSG_NOTICE([Stricter compiler flags enabled)])
+  AC_MSG_NOTICE([  STRICTER_CFLAGS: $STRICTER_CFLAGS])
+  AC_MSG_NOTICE([  STRICTER_CPPFLAGS: $STRICTER_CPPFLAGS])
+  AC_MSG_NOTICE([  STRICTER_LDFLAGS: $STRICTER_LDFLAGS])
+], [
+  AC_MSG_NOTICE([Stricter compiler flags disabled (use --enable-stricter to enable)])
+])
+AC_SUBST([STRICTER_CFLAGS])
+AC_SUBST([STRICTER_CPPFLAGS])
+AC_SUBST([STRICTER_LDFLAGS])
+
+
 AC_CONFIG_FILES([
 Makefile
 inc/Makefile

--- a/gitcompile
+++ b/gitcompile
@@ -2,11 +2,15 @@
 
 autoreconf -is
 
-export CFLAGS='-O2 -Wall -pipe -g'
+# Set default build flags if not already set
+# Users can override by setting CFLAGS before running this script
+if [ -z "$CFLAGS" ]; then
+  export CFLAGS="-O2 -Wall -pipe -g"
+fi
+
 echo "CFLAGS=$CFLAGS"
 echo "./configure $@"
 ./configure $@ || exit 1
-unset CFLAGS
 if [ -z "$GITCOMPILE_NO_MAKE" ]; then
   make
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,7 +70,6 @@ else
 libadsprpc_la_LIBADD = -ldl -lm $(USE_LOG) @YAML_LIBS@ @BSD_LIBS@
 libcdsprpc_la_LIBADD = -ldl -lm $(USE_LOG) @YAML_LIBS@ @BSD_LIBS@
 libsdsprpc_la_LIBADD = -ldl -lm $(USE_LOG) @YAML_LIBS@ @BSD_LIBS@
-libgdsprpc_la_LIBADD = -ldl -lm $(USE_LOG) @YAML_LIBS@ @BSD_LIBS@
 endif
 
 ADSP_CFLAGS = $(LIBDSPRPC_CFLAGS) -DDEFAULT_DOMAIN_ID=0
@@ -112,17 +111,6 @@ libsdsp_default_listener_la_DEPENDENCIES = libsdsprpc.la
 libsdsp_default_listener_la_LDFLAGS = libsdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@
 libsdsp_default_listener_la_CFLAGS = $(SDSP_CFLAGS) -DUSE_SYSLOG
 
-GDSP_CFLAGS = $(LIBDSPRPC_CFLAGS) -DDEFAULT_DOMAIN_ID=5
-
-libgdsprpc_la_SOURCES = $(LIBDSPRPC_SOURCES)
-libgdsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@
-libgdsprpc_la_CFLAGS = $(GDSP_CFLAGS)
-
-libgdsp_default_listener_la_SOURCES = $(LIBDEFAULT_LISTENER_SOURCES)
-libgdsp_default_listener_la_DEPENDENCIES = libcdsprpc.la
-libgdsp_default_listener_la_LDFLAGS = libcdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@
-libgdsp_default_listener_la_CFLAGS = $(GDSP_CFLAGS) -DUSE_SYSLOG
-
 bin_PROGRAMS = adsprpcd cdsprpcd sdsprpcd gdsprpcd
 
 adsprpcddir = $(libdir)
@@ -145,7 +133,7 @@ sdsprpcd_DEPENDENCIES = libsdsp_default_listener.la
 sdsprpcd_CFLAGS = -I$(top_srcdir)/inc -DDEFAULT_DOMAIN_ID=2 -DUSE_SYSLOG -DUSE_SDSP
 sdsprpcd_LDADD =  -ldl $(USE_LOG)
 
-
+# GDSP daemon shares CDSP libraries (not a typo)
 gdsprpcddir = $(libdir)
 gdsprpcd_SOURCES = dsprpcd.c
 gdsprpcd_DEPENDENCIES = libcdsp_default_listener.la

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,8 @@
 lib_LTLIBRARIES =
 
-LIBDSPRPC_CFLAGS = -fno-short-enums -U_DEBUG -DARM_ARCH_7A -DLE_ENABLE -DENABLE_UPSTREAM_DRIVER_INTERFACE -DUSE_SYSLOG -DCONFIG_BASE_DIR='"$(CONFIG_BASE_DIR)"' -DMACHINE_NAME_PATH='"/sys/firmware/devicetree/base/model"' -I$(top_srcdir)/inc
+LIBDSPRPC_CFLAGS = -fno-short-enums -U_DEBUG -DARM_ARCH_7A -DLE_ENABLE -DENABLE_UPSTREAM_DRIVER_INTERFACE -DUSE_SYSLOG -DCONFIG_BASE_DIR='"$(CONFIG_BASE_DIR)"' -DMACHINE_NAME_PATH='"/sys/firmware/devicetree/base/model"' -I$(top_srcdir)/inc @STRICTER_CFLAGS@ @STRICTER_CPPFLAGS@
+
+LIBDSPRPC_LDFLAGS = @STRICTER_LDFLAGS@
 
 if ANDROID_CC
 LIBDSPRPC_CFLAGS += -DDEFAULT_DSP_SEARCH_PATHS='";/vendor/lib/rfsa/adsp;/vendor/dsp;"'
@@ -76,39 +78,39 @@ ADSP_CFLAGS = $(LIBDSPRPC_CFLAGS) -DDEFAULT_DOMAIN_ID=0
 
 lib_LTLIBRARIES += libadsprpc.la
 libadsprpc_la_SOURCES = $(LIBDSPRPC_SOURCES)
-libadsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@
+libadsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libadsprpc_la_CFLAGS = $(ADSP_CFLAGS)
 
 lib_LTLIBRARIES += libadsp_default_listener.la
 libadsp_default_listener_la_SOURCES = $(LIBDEFAULT_LISTENER_SOURCES)
 libadsp_default_listener_la_DEPENDENCIES = libadsprpc.la
-libadsp_default_listener_la_LDFLAGS = libadsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@
+libadsp_default_listener_la_LDFLAGS = libadsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libadsp_default_listener_la_CFLAGS = $(ADSP_CFLAGS) -DUSE_SYSLOG
 
 CDSP_CFLAGS = $(LIBDSPRPC_CFLAGS) -DDEFAULT_DOMAIN_ID=3
 
 lib_LTLIBRARIES += libcdsprpc.la
 libcdsprpc_la_SOURCES = $(LIBDSPRPC_SOURCES)
-libcdsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@
+libcdsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libcdsprpc_la_CFLAGS = $(CDSP_CFLAGS)
 
 lib_LTLIBRARIES += libcdsp_default_listener.la
 libcdsp_default_listener_la_SOURCES = $(LIBDEFAULT_LISTENER_SOURCES)
 libcdsp_default_listener_la_DEPENDENCIES = libcdsprpc.la
-libcdsp_default_listener_la_LDFLAGS = libcdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@
+libcdsp_default_listener_la_LDFLAGS = libcdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libcdsp_default_listener_la_CFLAGS = $(CDSP_CFLAGS) -DUSE_SYSLOG
 
 SDSP_CFLAGS = $(LIBDSPRPC_CFLAGS) -DDEFAULT_DOMAIN_ID=2
 
 lib_LTLIBRARIES += libsdsprpc.la
 libsdsprpc_la_SOURCES = $(LIBDSPRPC_SOURCES)
-libsdsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@
+libsdsprpc_la_LDFLAGS = -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libsdsprpc_la_CFLAGS = $(SDSP_CFLAGS)
 
 lib_LTLIBRARIES += libsdsp_default_listener.la
 libsdsp_default_listener_la_SOURCES = $(LIBDEFAULT_LISTENER_SOURCES)
 libsdsp_default_listener_la_DEPENDENCIES = libsdsprpc.la
-libsdsp_default_listener_la_LDFLAGS = libsdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@
+libsdsp_default_listener_la_LDFLAGS = libsdsprpc.la -shared -module $(USE_LOG) -version-number @LT_VERSION_NUMBER@ $(LIBDSPRPC_LDFLAGS)
 libsdsp_default_listener_la_CFLAGS = $(SDSP_CFLAGS) -DUSE_SYSLOG
 
 bin_PROGRAMS = adsprpcd cdsprpcd sdsprpcd gdsprpcd

--- a/src/apps_mem_imp.c
+++ b/src/apps_mem_imp.c
@@ -17,6 +17,7 @@
 #include "remote64.h"
 #include "rpcmem_internal.h"
 #include "verify.h"
+#include <inttypes.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -122,8 +123,8 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
   VERIFYC(me, AEE_ERESOURCENOTFOUND);
   VERIFY(AEE_SUCCESS ==
          (nErr = get_unsigned_pd_attribute(domain, &unsigned_module)));
-  FASTRPC_ATRACE_BEGIN_L("%s called with rflag 0x%x, lflags 0x%x, len 0x%llx, "
-                         "heapid %d and unsigned PD %d",
+  FASTRPC_ATRACE_BEGIN_L("%s called with rflag 0x%x, lflags 0x%x, "
+                         "len 0x%" PRIx64 ", heapid %d and unsigned PD %d",
                          __func__, rflags, lflags, len, heapid,
                          unsigned_module);
   if (unsigned_module) {
@@ -196,7 +197,7 @@ bail:
       minfo = NULL;
     }
     VERIFY_EPRINTF("Error 0x%x: apps_mem_request_mmap64 failed for fd 0x%x of "
-                   "size %lld (lflags 0x%x, rflags 0x%x)\n",
+                   "size %" PRId64 " (lflags 0x%x, rflags 0x%x)\n",
                    nErr, fd, len, lflags, rflags);
   }
   FASTRPC_ATRACE_END();
@@ -228,8 +229,8 @@ __QAIC_IMPL(apps_mem_request_unmap64)(uint64_t vadsp,
   int domain = get_current_domain();
   apps_mem_info *me = NULL;
 
-  FASTRPC_ATRACE_BEGIN_L("%s called with vadsp 0x%llx, len 0x%llx", __func__,
-                         vadsp, len);
+  FASTRPC_ATRACE_BEGIN_L("%s called with vadsp 0x%" PRIx64 ", len 0x%" PRIx64,
+                         __func__, vadsp, len);
   GET_HASH_NODE(apps_mem_info, domain, me);
   VERIFYC(me, AEE_ERESOURCENOTFOUND);
 
@@ -275,8 +276,8 @@ __QAIC_IMPL(apps_mem_request_unmap64)(uint64_t vadsp,
   mfree = NULL;
 bail:
   if (nErr != AEE_SUCCESS) {
-    VERIFY_EPRINTF("Error 0x%x: apps_mem_request_unmap64 failed for size %lld "
-                   "(vadsp 0x%llx)\n",
+    VERIFY_EPRINTF("Error 0x%x: apps_mem_request_unmap64 failed for size "
+                   "%" PRId64 " (vadsp 0x%" PRIx64 ")\n",
                    nErr, len, vadsp);
   }
   FASTRPC_ATRACE_END();
@@ -345,7 +346,7 @@ __QAIC_IMPL_EXPORT int __QAIC_IMPL(apps_mem_share_unmap)(uint64_t vadsp, int siz
   nErr = apps_mem_request_unmap64(vadsp, len1);
   if (nErr != AEE_SUCCESS) {
     VERIFY_EPRINTF(
-        "Error 0x%x: apps_mem_share_unmap failed size %d (vadsp 0x%llx)\n",
+        "Error 0x%x: apps_mem_share_unmap failed size %d (vadsp 0x%" PRIx64 ")\n",
         nErr, size, vadsp);
   }
   return nErr;

--- a/src/apps_std_imp.c
+++ b/src/apps_std_imp.c
@@ -154,8 +154,8 @@ int apps_std_get_dirinfo(const apps_std_DIR *dir,
   } else {
     nErr = ESTALE;
     VERIFY_EPRINTF(
-        "Error 0x%x: %s: stale directory handle 0x%llx passed by DSP\n", nErr,
-        __func__, dir->handle);
+        "Error 0x%x: %s: stale directory handle 0x%" PRIx64 " passed by DSP\n",
+        nErr, __func__, dir->handle);
     goto bail;
   }
 bail:

--- a/src/apps_std_imp.c
+++ b/src/apps_std_imp.c
@@ -1008,19 +1008,24 @@ int fopen_from_dirlist(const char *dirList, const char *delim,
     const char *mode, const char *name, apps_std_FILE *psout) {
   int nErr = AEE_SUCCESS;
   char *absName = NULL, *dirName = NULL, *pos = NULL;
+  char *dirListCopy = NULL, *dirListPtr = NULL;
   uint16_t absNameLen = 0;
   int domain = GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(get_current_domain());
 
   VERIFYC(NULL != dirList, AEE_EBADPARM);
 
-  while (dirList) {
-    pos = strstr(dirList, delim);
-    dirName = dirList;
+  // Make a copy of dirList to avoid modifying caller's buffer
+  VERIFYC(NULL != (dirListCopy = strdup(dirList)), AEE_ENOMEMORY);
+  dirListPtr = dirListCopy;
+
+  while (dirListPtr) {
+    pos = strstr(dirListPtr, delim);
+    dirName = dirListPtr;
     if (pos) {
       *pos = '\0';
-      dirList = pos + strlen(delim);
+      dirListPtr = pos + strlen(delim);
     } else {
-      dirList = 0;
+      dirListPtr = 0;
     }
 
     // Append domain to path
@@ -1043,6 +1048,7 @@ int fopen_from_dirlist(const char *dirList, const char *delim,
       // Success
       FARF(ALWAYS, "Successfully opened file %s", absName);
       FREEIF(absName);
+      FREEIF(dirListCopy);
       return nErr;
     }
     FREEIF(absName);
@@ -1069,11 +1075,13 @@ int fopen_from_dirlist(const char *dirList, const char *delim,
                        strlen(TESTSIG_FILE_NAME)) != 0))
         FARF(ALWAYS, "Successfully opened file %s", name);
       FREEIF(absName);
+      FREEIF(dirListCopy);
       return nErr;
     }
   }
 bail:
   FREEIF(absName);
+  FREEIF(dirListCopy);
   return nErr;
 }
 

--- a/src/dsprpcd.c
+++ b/src/dsprpcd.c
@@ -150,7 +150,8 @@ int main(int argc, char *argv[]) {
     lib_unversioned = GDSP_LISTENER_UNVERSIONED;
     dsp_name = "GDSP";
   #else
-    goto bail;
+    VERIFY_EPRINTF("daemon exiting %x (no DSP type defined)", nErr);
+    return nErr;
   #endif
 
   // Parse command-line options
@@ -197,7 +198,6 @@ int main(int argc, char *argv[]) {
         usleep(100000);
   }
 
-  bail:
-    VERIFY_EPRINTF("daemon exiting %x", nErr);
-    return nErr;
+  VERIFY_EPRINTF("daemon exiting %x", nErr);
+  return nErr;
 }

--- a/src/dsprpcd.c
+++ b/src/dsprpcd.c
@@ -28,6 +28,7 @@
 #define SDSP_LISTENER_VERSIONED   "libsdsp_default_listener.so.1"
 #define SDSP_LISTENER_UNVERSIONED "libsdsp_default_listener.so"
 #endif
+/* GDSP uses CDSP libraries (not a typo) */
 #ifndef GDSP_LISTENER_VERSIONED
 #define GDSP_LISTENER_VERSIONED   "libcdsp_default_listener.so.1"
 #define GDSP_LISTENER_UNVERSIONED "libcdsp_default_listener.so"

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1560,14 +1560,13 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
      */
     if (strstr(pdName, get_domain_from_id(GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain))) &&
         strstr(pdName, FASTRPC_SESSION_URI)) {
-      strlcpy(pdName, pdName,
-                  (strlen(pdName) -
-                   strlen(get_domain_from_id(GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain))) -
-                   strlen(FASTRPC_SESSION1_URI) + 1));
+      /* Truncate string in place by null-terminating at desired length */
+      pdName[strlen(pdName) -
+             strlen(get_domain_from_id(GET_DOMAIN_FROM_EFFEC_DOMAIN_ID(domain))) -
+             strlen(FASTRPC_SESSION1_URI)] = '\0';
     } else if (strstr(pdName, get_domain_from_id(domain))) {
-      strlcpy(
-          pdName, pdName,
-          (strlen(pdName) - strlen(get_domain_from_id(domain)) + 1));
+      /* Truncate string in place by null-terminating at desired length */
+      pdName[strlen(pdName) - strlen(get_domain_from_id(domain))] = '\0';
     }
     VERIFYC(MAX_DSPPD_NAMELEN > strlen(pdName), AEE_EBADPARM);
     strlcpy(hlist[domain].dsppdname, pdName, strlen(pdName) + 1);

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1170,8 +1170,11 @@ int remote_handle_invoke_domain(int domain, remote_handle handle,
 
   if (IS_QTF_TRACING_ENABLED(hlist[domain].procattrs) &&
       !IS_STATIC_HANDLE(handle) && trace_marker_fd > 0) {
-    write(trace_marker_fd, INVOKE_BEGIN_TRACE_STR, invoke_begin_trace_strlen);
-    trace_enabled = true;
+    /* Write begin trace marker; only enable tracing if write succeeds.
+     * This ensures we don't attempt to write an end marker if begin failed. */
+    ssize_t ret = write(trace_marker_fd, INVOKE_BEGIN_TRACE_STR, invoke_begin_trace_strlen);
+    if (ret > 0)
+      trace_enabled = true;
   }
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
@@ -1406,7 +1409,10 @@ bail:
     }
   }
   if (trace_enabled) {
-    write(trace_marker_fd, INVOKE_END_TRACE_STR, invoke_end_trace_strlen);
+    /* Write end trace marker. Store return value to satisfy warn_unused_result,
+     * but don't check it since trace writes are optional and failures are non-critical. */
+    ssize_t ret __attribute__((unused));
+    ret = write(trace_marker_fd, INVOKE_END_TRACE_STR, invoke_end_trace_strlen);
   }
   if (nErr != AEE_SUCCESS) {
     if ((nErr == -1) && (errno == ECONNRESET)) {

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3887,8 +3887,8 @@ static void exit_thread(void *value) {
           INVALID_HANDLE) {
         nErr = adsp_current_process1_thread_exit(handle);
         if (nErr) {
-          FARF(RUNTIME_RPC_HIGH, "%s: nErr:0x%x, dom:%d, h:0x%llx", __func__, nErr,
-               domain, handle);
+          FARF(RUNTIME_RPC_HIGH, "%s: nErr:0x%x, dom:%d, h:0x%" PRIx64,
+               __func__, nErr, domain, handle);
         }
       } else if (domain == DEFAULT_DOMAIN_ID) {
         nErr = adsp_current_process_thread_exit();

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -782,8 +782,8 @@ int remote_mem_map(int domain, int fd, int flags, uint64_t vaddr, size_t size,
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
   FARF(RUNTIME_RPC_HIGH,
-       "%s: domain %d fd %d addr 0x%llx size 0x%zx flags 0x%x", __func__,
-       domain, fd, vaddr, size, flags);
+       "%s: domain %d fd %d addr 0x%" PRIx64 " size 0x%zx flags 0x%x",
+       __func__, domain, fd, vaddr, size, flags);
 
   VERIFYC(fd >= 0, AEE_EBADPARM);
   VERIFYC(size >= 0, AEE_EBADPARM);
@@ -805,8 +805,8 @@ bail:
     nErr = convert_kernel_to_user_error(nErr, errno);
     if (0 == check_rpc_error(nErr)) {
       FARF(ERROR,
-           "Error 0x%x: %s failed to map buffer fd %d addr 0x%llx size 0x%zx "
-           "domain %d flags %d errno %s",
+           "Error 0x%x: %s failed to map buffer fd %d addr 0x%" PRIx64
+           " size 0x%zx domain %d flags %d errno %s",
            nErr, __func__, fd, vaddr, size, domain, flags, strerror(errno));
     }
   }
@@ -820,8 +820,8 @@ int remote_mem_unmap(int domain, uint64_t raddr, size_t size) {
 
   VERIFYC(size >= 0, AEE_EBADPARM);
   VERIFYC(raddr != 0, AEE_EBADPARM);
-  FARF(RUNTIME_RPC_HIGH, "%s: domain %d addr 0x%llx size 0x%zx", __func__,
-       domain, raddr, size);
+  FARF(RUNTIME_RPC_HIGH, "%s: domain %d addr 0x%" PRIx64 " size 0x%zx",
+       __func__, domain, raddr, size);
   if (domain == -1) {
     domain = get_current_domain();
   }
@@ -837,8 +837,8 @@ bail:
     nErr = convert_kernel_to_user_error(nErr, errno);
     if (0 == check_rpc_error(nErr)) {
       FARF(ERROR,
-           "Error 0x%x: %s failed to unmap buffer addr 0x%llx size 0x%zx "
-           "domain %d errno %s",
+           "Error 0x%x: %s failed to unmap buffer addr 0x%" PRIx64
+           " size 0x%zx domain %d errno %s",
            nErr, __func__, raddr, size, domain, strerror(errno));
     }
   }
@@ -878,8 +878,8 @@ bail:
   if (nErr != AEE_SUCCESS) {
     nErr = convert_kernel_to_user_error(nErr, errno);
     FARF(ERROR,
-         "Error 0x%x: %s failed for fd 0x%x of size %lld (flags 0x%x, vaddrin "
-         "0x%llx) errno %s\n",
+         "Error 0x%x: %s failed for fd 0x%x of size %" PRId64 " (flags 0x%x, "
+         "vaddrin 0x%" PRIx64 ") errno %s\n",
          nErr, __func__, fd, size, flags, vaddrin, strerror(errno));
   }
   return nErr;
@@ -905,8 +905,8 @@ int remote_mmap64(int fd, uint32_t flags, uint64_t vaddrin, int64_t size,
 bail:
   if ((nErr != AEE_SUCCESS) && (log == 1)) {
     FARF(ERROR,
-         "Error 0x%x: %s failed for fd 0x%x of size %lld (flags 0x%x, vaddrin "
-         "0x%llx)\n",
+         "Error 0x%x: %s failed for fd 0x%x of size %" PRId64 " (flags 0x%x, "
+         "vaddrin 0x%" PRIx64 ")\n",
          nErr, __func__, fd, size, flags, vaddrin);
   }
   return nErr;
@@ -961,8 +961,8 @@ bail:
   if (nErr != AEE_SUCCESS) {
     nErr = convert_kernel_to_user_error(nErr, errno);
     FARF(ERROR,
-         "Error 0x%x: %s failed for size %lld (vaddrout 0x%llx) errno %s\n",
-         nErr, __func__, size, vaddrout, strerror(errno));
+         "Error 0x%x: %s failed for size %" PRId64 " (vaddrout 0x%" PRIx64 ") "
+         "errno %s\n", nErr, __func__, size, vaddrout, strerror(errno));
   }
   return nErr;
 }

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -928,7 +928,6 @@ bail:
 int remote_munmap64(uint64_t vaddrout, int64_t size) {
   int dev, domain = DEFAULT_DOMAIN_ID, nErr = AEE_SUCCESS, ref = 0;
   uint32_t rflags;
-  QNode *pn, *pnn;
   struct fastrpc_remote_map *mNode = NULL;
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));

--- a/src/listener_android.c
+++ b/src/listener_android.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include "AEEStdErr.h"
 #include "AEEstd.h"
@@ -132,8 +133,8 @@ static void listener(listener_config *me) {
   memset(args, 0, sizeof(args));
   if (eheap || eflags || emin) {
     FARF(RUNTIME_RPC_HIGH,
-         "listener using ion heap: %d flags: %x cache: %lld\n", (int)heapid,
-         (int)flags, cache_size);
+         "listener using ion heap: %d flags: %x cache: %" PRId64 "\n",
+         (int)heapid, (int)flags, cache_size);
   }
 
   do {

--- a/src/mod_table.c
+++ b/src/mod_table.c
@@ -549,7 +549,9 @@ static int open_mod_table_open_dynamic(struct open_mod_table *me,
         break;
       }
     }
-    rv = snprintf(tmp, tmplen, "%s_system.so", tmp);
+    /* Append "_system.so" to base name (avoid overlapping buffers in snprintf) */
+    strlcat(tmp, "_system.so", tmplen);
+    rv = strlen(tmp);
     VERIFYC((rv > 0) && (tmplen >= rv), AEE_EBADPARM);
     FARF(RUNTIME_RPC_HIGH, "calling dlopen for %s", tmp);
     dm->dlhandle = DLOPEN(tmp, RTLD_NOW);


### PR DESCRIPTION
Various build warning fixes, and improvements to CI builds flags.
- **Fix format string warnings for 64-bit integer types**
- **Fix const qualifier warnings from fopen_from_dirlist**
- **Fix -Wrestrict warnings due to overlapping buffers**
- **Fix -Wint-in-bool-context warnings in _ALLOCATE**
- **Fix unused label warnings in dsprpcd daemons**
- **Fix GDSP library build configuration**
- **Fix unused result warnings for trace marker writes**
- **Add and use --enable-stricter configure flag**
- **Remove unused userspace allocation check**

Fixes: #329
