### PR TITLE
adspmsgd: route DSP runtime logs via syslog when enabled

### DIFF
--- a/src/adspmsgd_printf.c
+++ b/src/adspmsgd_printf.c
@@ -5,6 +5,12 @@
 #include "remote.h"
 
 #include <stdio.h>
+#ifdef __ANDROID__
+#include <android/log.h>
+#endif
+#ifdef USE_SYSLOG
+#include <syslog.h>
+#endif
 
 #define LOG_NODE_SIZE 256
 #define LOG_FILENAME_SIZE 30
@@ -54,5 +60,11 @@ int adspmsgd_apps_log(const unsigned char *log_message_buffer,
   return 0;
 }
 void adspmsgd_log_message(char *format, char *msg) {
-  printf("adsprpc:dsp: %s\n", msg);
+#ifdef __ANDROID__
+   __android_log_print(ANDROID_LOG_VERBOSE,"adsprpc",format, msg);
+#elif defined(USE_SYSLOG)
+   syslog(LOG_INFO,"adsprpc:%s ", msg);
+#else
+   printf("adsprpc:%s\n", msg);
+#endif
 }


### PR DESCRIPTION
DSP runtime logs emitted by adspmsgd are currently written to stdout using printf(), which causes them to be routed to the console instead of systemd journal on Linux systems.

Add support for routing logs via syslog when USE_SYSLOG is enabled, and use platform-specific logging backends where applicable. This ensures that runtime DSP logs are correctly captured by journalctl on Linux while preserving existing Android logging behavior.

Fallback to stdout is retained for non-Android and non-syslog builds.