### PR TITLE
fastrpc: fallback to fastrpc_mmap_internal for unsupported flags

### DIFF
--- a/inc/fastrpc_mem.h
+++ b/inc/fastrpc_mem.h
@@ -102,4 +102,11 @@ int fastrpc_mmap_internal(int domain, int fd, void *vaddr, int offset, size_t le
  */
 int fastrpc_munmap_internal(int domain, uint64_t raddr, size_t length);
 
+#define ADSP_MMAP_HEAP_ADDR 4
+#define ADSP_MMAP_REMOTE_HEAP_ADDR 8
+#define ADSP_MMAP_ADD_PAGES 0x1000
+#define ADSP_MMAP_ADD_PAGES_LLC 0x3000
+#define FASTRPC_ALLOC_HLOS_FD                                                  \
+  0x10000 /* Flag to allocate HLOS FD to be shared with DSP */
+
 #endif //FASTRPC_MEM_H

--- a/src/apps_mem_imp.c
+++ b/src/apps_mem_imp.c
@@ -24,12 +24,6 @@
 #include <sys/mman.h>
 #include "fastrpc_hash_table.h"
 
-#define ADSP_MMAP_HEAP_ADDR 4
-#define ADSP_MMAP_REMOTE_HEAP_ADDR 8
-#define ADSP_MMAP_ADD_PAGES 0x1000
-#define ADSP_MMAP_ADD_PAGES_LLC 0x3000
-#define FASTRPC_ALLOC_HLOS_FD                                                  \
-  0x10000 /* Flag to allocate HLOS FD to be shared with DSP */
 
 typedef struct {
 	QList mem_list;
@@ -163,13 +157,23 @@ __QAIC_IMPL(apps_mem_request_map64)(int heapid, uint32_t lflags, uint32_t rflags
      */
     *vadsp = (uint64_t)fd;
   } else {
-    VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
-            AEE_ENORPCMEMORY);
-    fd = rpcmem_to_fd_internal(buf);
-    VERIFYC(fd > 0, AEE_EBADPARM);
+    /* Memory for unsignedPD's user-heap will be allocated in userspace for
+     * security reasons. Memory for signedPD's user-heap will be allocated in
+     * kernel.
+     */
+    if (((rflags != ADSP_MMAP_ADD_PAGES) &&
+         (rflags != ADSP_MMAP_ADD_PAGES_LLC)) ||
+        (((rflags == ADSP_MMAP_ADD_PAGES) ||
+          (rflags == ADSP_MMAP_ADD_PAGES_LLC)) &&
+         (unsigned_module && ualloc_support))) {
+      VERIFYC(NULL != (buf = rpcmem_alloc_internal(heapid, lflags, len)),
+              AEE_ENORPCMEMORY);
+      fd = rpcmem_to_fd_internal(buf);
+      VERIFYC(fd > 0, AEE_EBADPARM);
+    }
     VERIFY(AEE_SUCCESS ==
-           (nErr = fastrpc_mmap_internal(domain, fd, buf, 0, len,
-                                         rflags, vadsp)));
+            (nErr = remote_mmap64_internal(fd, rflags, (uint64_t)buf, len,
+                                          (uint64_t *)vadsp)));
     pbuf = (uint64_t)buf;
     *vapps = pbuf;
     minfo->vapps = *vapps;
@@ -240,27 +244,17 @@ __QAIC_IMPL(apps_mem_request_unmap64)(uint64_t vadsp,
   pthread_mutex_unlock(&me->mem_mut);
 
   /* If apps_mem_request_map64 was called with flag FASTRPC_ALLOC_HLOS_FD,
-   * use fastrpc_munmap. For ADSP_MMAP_HEAP_ADDR and ADSP_MMAP_REMOTE_HEAP_ADDR,
-   * use remote_munmap64. For other cases, use fastrpc_munmap_internal.
+   * use fastrpc_munmap else use remote_munmap64 to unmap.
    */
    if(mfree && mfree->rflags == FASTRPC_ALLOC_HLOS_FD) {
       fd = (int)vadsp;
       VERIFY(AEE_SUCCESS == (nErr = fastrpc_munmap(domain, fd, 0, len)));
-   } else if (mfree && (mfree->rflags == ADSP_MMAP_HEAP_ADDR ||
-                        mfree->rflags == ADSP_MMAP_REMOTE_HEAP_ADDR)) {
-      /* These cases use remote_mmap64_internal, so use remote_munmap64 */
-      VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
    } else if (mfree || fastrpc_get_pd_type(domain) == AUDIO_STATICPD){
       /*
        * Map info not available for Audio static PD after daemon reconnect,
        * So continue to unmap to avoid driver global maps leak.
-       * For other cases, use fastrpc_munmap_internal as they were mapped with fastrpc_mmap_internal.
        */
-      if (mfree) {
-         VERIFY(AEE_SUCCESS == (nErr = fastrpc_munmap_internal(domain, (uint64_t)vadsp, len)));
-      } else {
-         VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
-      }
+      VERIFY(AEE_SUCCESS == (nErr = remote_munmap64((uint64_t)vadsp, len)));
       if (!mfree)
          goto bail;
    }

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -110,6 +110,18 @@ struct static_map_list {
   pthread_mutex_t mut;
 };
 
+struct fastrpc_remote_map {
+  QNode qn;
+  uint64_t vadsp;
+  uint32_t flags;
+};
+
+struct fastrpc_remote_map_list {
+  QList ql;
+  pthread_mutex_t mut;
+};
+
+static struct fastrpc_remote_map_list memlist[NUM_DOMAINS_EXTEND];
 static struct static_map_list smaplst[NUM_DOMAINS_EXTEND];
 static struct mem_to_fd_list fdlist;
 static struct dma_handle_info dhandles[MAX_DMA_HANDLES];
@@ -128,6 +140,8 @@ int fastrpc_mem_init(void) {
   FOR_EACH_EFFECTIVE_DOMAIN_ID(ii) {
     QList_Ctor(&smaplst[ii].ql);
     pthread_mutex_init(&smaplst[ii].mut, 0);
+    QList_Ctor(&memlist[ii].ql);
+    pthread_mutex_init(&memlist[ii].mut, 0);
   }
   return 0;
 }
@@ -138,8 +152,33 @@ int fastrpc_mem_deinit(void) {
   pthread_mutex_destroy(&fdlist.mut);
   FOR_EACH_EFFECTIVE_DOMAIN_ID(ii) {
     pthread_mutex_destroy(&smaplst[ii].mut);
+    pthread_mutex_destroy(&memlist[ii].mut);
   }
   return 0;
+}
+
+static int fastrpc_remote_map_lookup(int domain, uint64_t vadsp, uint32_t *flags_out, struct fastrpc_remote_map **out)
+{
+    QNode *pn, *pnn;
+    struct fastrpc_remote_map *mNode;
+
+    if (!flags_out || !out)
+      return AEE_EBADPARM;
+
+    *out = NULL;
+    pthread_mutex_lock(&memlist[domain].mut);
+    QLIST_NEXTSAFE_FOR_ALL(&memlist[domain].ql, pn, pnn) {
+        mNode = STD_RECOVER_REC(struct fastrpc_remote_map, qn, pn);
+        if (mNode->vadsp == vadsp) {
+            *flags_out = mNode->flags;
+            *out = mNode;
+            QNode_DequeueZ(&mNode->qn);
+            pthread_mutex_unlock(&memlist[domain].mut);
+            return AEE_SUCCESS;
+        }
+    }
+    pthread_mutex_unlock(&memlist[domain].mut);
+    return AEE_ERESOURCENOTFOUND;
 }
 
 static void *remote_register_fd_attr(int fd, size_t size, int attr) {
@@ -818,8 +857,22 @@ int remote_mmap64_internal(int fd, uint32_t flags, uint64_t vaddrin,
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
   VERIFYM(-1 != dev, AEE_ERPC, "Invalid device\n");
-  nErr = ioctl_mmap(dev, MMAP_64, flags, 0, fd, 0, size, vaddrin, &vaout);
+  if (flags == ADSP_MMAP_ADD_PAGES || flags == ADSP_MMAP_REMOTE_HEAP_ADDR) { 
+    nErr = ioctl_mmap(dev, MMAP_64, flags, 0, fd, 0, size, vaddrin, &vaout);
+	} else {
+    VERIFY(AEE_SUCCESS ==
+           (nErr = fastrpc_mmap_internal(domain, fd, (void *)(uintptr_t)vaddrin, 0, size,
+                                        flags, &vaout)));
+  }
   *vaddrout = vaout;
+  pthread_mutex_lock(&memlist[domain].mut);
+  struct fastrpc_remote_map *mNode = malloc(sizeof(*mNode));
+  if (mNode) {
+    mNode->vadsp = vaout;
+    mNode->flags = flags;
+    QList_AppendNode(&memlist[domain].ql, &mNode->qn);
+  }
+  pthread_mutex_unlock(&memlist[domain].mut);
 bail:
   FASTRPC_PUT_REF(domain);
   if (nErr != AEE_SUCCESS) {
@@ -874,6 +927,9 @@ bail:
 
 int remote_munmap64(uint64_t vaddrout, int64_t size) {
   int dev, domain = DEFAULT_DOMAIN_ID, nErr = AEE_SUCCESS, ref = 0;
+  uint32_t rflags;
+  QNode *pn, *pnn;
+  struct fastrpc_remote_map *mNode = NULL;
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
@@ -883,7 +939,23 @@ int remote_munmap64(uint64_t vaddrout, int64_t size) {
   /* Don't open session in unmap. Return success if device already closed */
   FASTRPC_GET_REF(domain);
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_session_dev(domain, &dev)));
-  nErr = ioctl_munmap(dev, MUNMAP_64, 0, 0, -1, size, vaddrout);
+
+  if (AEE_SUCCESS == fastrpc_remote_map_lookup(domain, vaddrout, &rflags, &mNode)) {
+    if (rflags == ADSP_MMAP_ADD_PAGES || rflags == ADSP_MMAP_REMOTE_HEAP_ADDR) { 
+      nErr = ioctl_munmap(dev, MUNMAP_64, 0, 0, -1, size, vaddrout);
+	  } else {
+      nErr = fastrpc_munmap_internal(domain, (uint64_t)vaddrout, size);
+    }
+    if (nErr == AEE_SUCCESS) {
+      free(mNode);
+    } else {
+      pthread_mutex_lock(&memlist[domain].mut);
+      QList_AppendNode(&memlist[domain].ql, &mNode->qn);
+      pthread_mutex_unlock(&memlist[domain].mut);
+    }
+  } else {
+    nErr = ioctl_munmap(dev, MUNMAP_64, 0, 0, -1, size, vaddrout);
+  }
 bail:
   FASTRPC_PUT_REF(domain);
   if (nErr != AEE_SUCCESS) {


### PR DESCRIPTION
remote_mmap64_internal() currently uses the MMAP_64 ioctl for all mapping flags. However, MMAP_64 is only supported for specific use cases such as adding pages or mapping the remote heap.

Update remote_mmap64_internal() to route only ADSP_MMAP_ADD_PAGES and ADSP_MMAP_REMOTE_HEAP_ADDR through the MMAP_64 ioctl. All other flags now fall back to fastrpc_mmap_internal(), which provides broader backend support.

Because the use of fastrpc_mmap_internal has been moved inside remote_mmap64_internal, the application of fastrpc_mmap_internal in apps_mem_imp.c will be reverted.