### PR TITLE
Move GDSP domain IDs from remote.h to fastrpc_common.h

### DIFF
--- a/inc/fastrpc_common.h
+++ b/inc/fastrpc_common.h
@@ -49,6 +49,10 @@
 #define DOMAIN_NAME_IN_URI 1 // Domain name with standard module URI
 #define DOMAIN_NAME_STAND_ALONE 2 // Stand-alone domain name
 
+/* GDSP domain IDs - internal use only, not part of Hexagon SDK remote.h */
+#define GDSP0_DOMAIN_ID   5
+#define GDSP1_DOMAIN_ID   6
+
 #define PROFILE(time_taken, ff) \
 { \
 	struct timeval tv1, tv2; \

--- a/inc/remote.h
+++ b/inc/remote.h
@@ -122,8 +122,6 @@ extern "C" {
 #define SDSP_DOMAIN_ID    2
 #define CDSP_DOMAIN_ID    3
 #define CDSP1_DOMAIN_ID   4
-#define GDSP0_DOMAIN_ID   5
-#define GDSP1_DOMAIN_ID   6
 
 /** Supported Domain Names */
 #define ADSP_DOMAIN_NAME "adsp"


### PR DESCRIPTION
GDSP0_DOMAIN_ID and GDSP1_DOMAIN_ID are internal platform-specific constants not part of the Hexagon SDK API. Move them out of the inc/remote.h into inc/fastrpc_common.h to align remote.h with the Hexagon SDK remote.h surface.