### PR TITLE
Fix mem leak

### DIFF
--- a/inc/fastrpc_config.h
+++ b/inc/fastrpc_config.h
@@ -209,6 +209,8 @@ int fastrpc_config_get_caller_stack_num(void);
   * @return integer - 0 for success, non-zero for error cases.
   **/
 int fastrpc_config_init();
+// function to release unused ptr
+void fastrpc_config_deinit();
 
 /*
  * fastrpc_config_is_setdmabufname_enabled() - Check if DMA allocated buffer

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3850,6 +3850,7 @@ static void fastrpc_apps_user_deinit(void) {
     hlist = NULL;
   }
   fastrpc_context_table_deinit();
+  fastrpc_config_deinit();
   deinit_process_signals();
   fastrpc_notif_deinit();
   apps_mem_table_deinit();

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1021,10 +1021,14 @@ static void fastrpc_clear_handle_list(uint32_t req, int domain) {
     if (!QList_IsNull(&hlist[domain].ql)) {
       while ((pn = QList_Pop(&hlist[domain].ql))) {
         struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+        if (hi->name)
+          free(hi->name);
         free(hi);
         hi = NULL;
       }
     }
+    hlist[domain].domainsCount = 0;
+    hlist[domain].constCount = 0;
     pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
@@ -1033,22 +1037,32 @@ static void fastrpc_clear_handle_list(uint32_t req, int domain) {
     if (!QList_IsNull(&hlist[domain].nql)) {
       while ((pn = QList_Pop(&hlist[domain].nql))) {
         struct handle_info *h = STD_RECOVER_REC(struct handle_info, qn, pn);
+        if (h->name)
+          free(h->name);
         free(h);
         h = NULL;
       }
     }
+    hlist[domain].nondomainsCount = 0;
     pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
   case REVERSE_HANDLE_LIST_ID: {
+    pthread_mutex_lock(&hlist[domain].lmut);
     if (!QList_IsNull(&hlist[domain].rql)) {
       while ((pn = QList_Pop(&hlist[domain].rql))) {
         struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+        pthread_mutex_unlock(&hlist[domain].lmut);
         close_reverse_handle(hi->local, dlerrstr, sizeof(dlerrstr), &dlerr);
+        pthread_mutex_lock(&hlist[domain].lmut);
+        if (hi->name)
+          free(hi->name);
         free(hi);
         hi = NULL;
       }
     }
+    hlist[domain].reverseCount = 0;
+    pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
   default: {
@@ -1586,6 +1600,10 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
     } else if (!strncmp(pdName, "oispd", strlen("oispd"))) {
       *ph = OISPD_HANDLE;
       hlist[domain].dsppd = OIS_STATICPD;
+    }
+    if (pdname_uri) {
+      free(pdname_uri);
+      pdname_uri = NULL;
     }
     return AEE_SUCCESS;
   }

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -1022,10 +1022,14 @@ static void fastrpc_clear_handle_list(uint32_t req, int domain) {
     if (!QList_IsNull(&hlist[domain].ql)) {
       while ((pn = QList_Pop(&hlist[domain].ql))) {
         struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+        if (hi->name)
+          free(hi->name);
         free(hi);
         hi = NULL;
       }
     }
+    hlist[domain].domainsCount = 0;
+    hlist[domain].constCount = 0;
     pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
@@ -1034,22 +1038,32 @@ static void fastrpc_clear_handle_list(uint32_t req, int domain) {
     if (!QList_IsNull(&hlist[domain].nql)) {
       while ((pn = QList_Pop(&hlist[domain].nql))) {
         struct handle_info *h = STD_RECOVER_REC(struct handle_info, qn, pn);
+        if (h->name)
+          free(h->name);
         free(h);
         h = NULL;
       }
     }
+    hlist[domain].nondomainsCount = 0;
     pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
   case REVERSE_HANDLE_LIST_ID: {
+    pthread_mutex_lock(&hlist[domain].lmut);
     if (!QList_IsNull(&hlist[domain].rql)) {
       while ((pn = QList_Pop(&hlist[domain].rql))) {
         struct handle_info *hi = STD_RECOVER_REC(struct handle_info, qn, pn);
+        pthread_mutex_unlock(&hlist[domain].lmut);
         close_reverse_handle(hi->local, dlerrstr, sizeof(dlerrstr), &dlerr);
+        pthread_mutex_lock(&hlist[domain].lmut);
+        if (hi->name)
+          free(hi->name);
         free(hi);
         hi = NULL;
       }
     }
+    hlist[domain].reverseCount = 0;
+    pthread_mutex_unlock(&hlist[domain].lmut);
     break;
   }
   default: {
@@ -1592,6 +1606,10 @@ int remote_handle_open_domain(int domain, const char *name, remote_handle *ph,
     } else if (!strncmp(pdName, "oispd", strlen("oispd"))) {
       *ph = OISPD_HANDLE;
       hlist[domain].dsppd = OIS_STATICPD;
+    }
+    if (pdname_uri) {
+      free(pdname_uri);
+      pdname_uri = NULL;
     }
     return AEE_SUCCESS;
   }

--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -3875,6 +3875,7 @@ static void fastrpc_apps_user_deinit(void) {
     hlist = NULL;
   }
   fastrpc_context_table_deinit();
+  fastrpc_config_deinit();
   deinit_process_signals();
   fastrpc_notif_deinit();
   apps_mem_table_deinit();

--- a/src/fastrpc_config.c
+++ b/src/fastrpc_config.c
@@ -442,3 +442,14 @@ bail:
   }
   return nErr;
 }
+
+void fastrpc_config_deinit() {
+  if (frpc_config.farf_log_filename) {
+    free(frpc_config.farf_log_filename);
+    frpc_config.farf_log_filename = NULL;
+  }
+  if (frpc_config.farf_log_filename_userspace) {
+    free(frpc_config.farf_log_filename_userspace);
+    frpc_config.farf_log_filename_userspace = NULL;
+  }
+}

--- a/src/fastrpc_log.c
+++ b/src/fastrpc_log.c
@@ -180,6 +180,8 @@ void HAP_debug_runtime(int level, const char *file, int line,
     va_end(argp);
     log = (char *)malloc(sizeof(char) * MAX_FARF_LEN);
     if (log == NULL) {
+      free(buf);
+      buf = NULL;
       return;
     }
     snprintf(log, MAX_FARF_LEN, "%d:%d:%s:%s:%d: %s", getpid(), gettid(),


### PR DESCRIPTION
Free hi->name & h->name in cleanup path, and free pdname_uri in open path.
Add lock/unlock around pop loop in REVERSE_HANDLE_LIST_ID cleanup.
Add a new config deinit path to free FARF log filename buffers allocated during config init, ensuring init/deinit are paired.