### PR TITLE
ci: Switch workflows to pull_request event

### DIFF
--- a/.github/workflows/pkg-build-pr-check.yml
+++ b/.github/workflows/pkg-build-pr-check.yml
@@ -35,5 +35,3 @@ jobs:
       upstream-repo-ref: ${{ github.event.pull_request.head.ref }}
       pkg-repo: ${{vars.PKG_REPO_GITHUB_NAME}}
       pr-number: ${{github.event.pull_request.number}}
-    secrets:
-      TOKEN: ${{ secrets.DEB_PKG_BOT_CI_TOKEN }}

--- a/.github/workflows/pkg-build-pr-check.yml
+++ b/.github/workflows/pkg-build-pr-check.yml
@@ -11,7 +11,7 @@ description: |
   a full build of the package if it were to include these changes.
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main, development ]
     types:
       - ready_for_review

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -15,7 +15,7 @@ on:
     - 'main'
     - 'development'
   workflow_dispatch:
-  pull_request_target: # requiring access to base repo
+  pull_request: # requiring access to base repo
     types: [opened, synchronize, reopened]
     branches:
     - 'main'

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -1,6 +1,7 @@
 name: Prevent pull request to main
 on:
-  pull_request_target:
+  pull_request:
+    branches: [ main ]
     types:
       - opened
       - reopened


### PR DESCRIPTION
Replace pull_request_target with pull_request in PR workflows to follow GitHub security practices and avoid elevated permissions during PR validation.