### PR TITLE
Add man pages for fastrpc and daemons

### DIFF
--- a/Docs/manpages/Makefile.am
+++ b/Docs/manpages/Makefile.am
@@ -1,0 +1,17 @@
+man8_MANS = dsprpcd.8
+man3_MANS = fastrpc.3
+
+EXTRA_DIST = dsprpcd.8 fastrpc.3
+
+install-data-hook:
+	cd $(DESTDIR)$(mandir)/man8 && \
+	ln -sf dsprpcd.8 adsprpcd.8 && \
+	ln -sf dsprpcd.8 cdsprpcd.8 && \
+	ln -sf dsprpcd.8 gdsprpcd.8 && \
+	ln -sf dsprpcd.8 sdsprpcd.8
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(mandir)/man8/adsprpcd.8
+	rm -f $(DESTDIR)$(mandir)/man8/cdsprpcd.8
+	rm -f $(DESTDIR)$(mandir)/man8/gdsprpcd.8
+	rm -f $(DESTDIR)$(mandir)/man8/sdsprpcd.8

--- a/Docs/manpages/dsprpcd.8
+++ b/Docs/manpages/dsprpcd.8
@@ -1,0 +1,192 @@
+.TH dsprpcd 8 "May 2026" "fastrpc" "System Administration"
+
+.SH NAME
+adsprpcd, cdsprpcd, gdsprpcd, sdsprpcd \- FastRPC DSP daemon
+
+.SH SYNOPSIS
+.B adsprpcd
+[\fB\-h\fR | \fB\-\-help\fR]
+\fIpd_name\fR \fIdomain\fR
+.br
+.B cdsprpcd
+[\fB\-h\fR | \fB\-\-help\fR]
+\fIpd_name\fR \fIdomain\fR
+.br
+.B gdsprpcd
+[\fB\-h\fR | \fB\-\-help\fR]
+\fIpd_name\fR \fIdomain\fR
+.br
+.B sdsprpcd
+[\fB\-h\fR | \fB\-\-help\fR]
+\fIpd_name\fR \fIdomain\fR
+
+
+.SH DESCRIPTION
+.B dsprpcd
+is a userspace daemon that establishes and maintains FastRPC communication between the 
+application processor (HLOS: High-Level Operating System, e.g., Linux) and a Digital Signal Processor (DSP).
+
+The daemon is typically executed under different names (adsprpcd, cdsprpcd, gdsprpcd, sdsprpcd), 
+with each name targeting a specific DSP domain:
+.TP
+.B adsprpcd
+Audio DSP (ADSP)
+.TP
+.B cdsprpcd
+Compute DSP (CDSP)
+.TP
+.B gdsprpcd
+General purpose DSP (GDSP)
+.TP
+.B sdsprpcd
+Sensor DSP (SDSP)
+
+.PP
+The daemon acts as a default listener for DSP Protection Domains (PDs),
+handling reverse-RPC requests from DSP firmware that require host-side
+services.
+
+A Protection Domain is an isolated process and memory space that lets a
+component run independently so it can be restarted without affecting
+others.
+
+These services include:
+.IP \[bu] 2
+File system access via host-side interfaces (e.g., file open, read, write operations)
+.IP \[bu]
+Dynamic memory allocation requests from DSP to host memory
+.IP \[bu]
+Logging of DSP messages and exceptions
+
+.PP
+The daemon typically runs in the foreground and may be managed by init systems 
+(e.g., systemd) for automatic restart and lifecycle management.
+
+It communicates with the DSP through FastRPC device nodes, typically located under:
+.I /dev/fastrpc-*
+
+The daemon requires appropriate permissions to access these device nodes 
+and to perform system-level operations.
+
+.PP
+When running, the daemon maintains a persistent session with the DSP and 
+processes incoming requests in an event-driven manner.
+
+.SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Display help information and exit.
+
+.TP
+.I pd_name domain
+Start the daemon for a specific Protection Domain (PD) and DSP domain.
+
+
+The domain identifies the specific DSP instance. Some DSP types
+provide multiple instances (e.g., cdsp0, cdsp1), while others have
+a single instance (e.g., adsp). In such cases, the domain argument
+is primarily relevant for DSPs with multiple instances.
+
+.PP
+Examples:
+.br
+\fBrootpd adsp\fR
+.br
+\fBrootpd cdsp0\fR
+.br
+\fBrootpd gdsp0\fR
+.br
+\fBrootpd sdsp\fR
+
+.SH FUNCTIONALITY
+
+.SS rootpd (Root PD / Guest OS)
+.PP
+\fBUsage:\fR
+.nf
+cdsprpcd
+cdsprpcd rootpd cdsp1
+.fi
+
+.PP
+\fBPurpose:\fR
+Attaches to the DSP Root Protection Domain (PD), which runs the guest
+operating system (typically QuRT). It acts as the default listener for
+reverse-RPC requests.
+
+Provides file operations for components running in the Root PD. Dynamic
+loading (dlopen) is not supported in Root PD due to security constraints.
+
+Routes DSP exception logs to host logging (syslog/dmesg), which is the
+primary client-facing use case.
+
+.PP
+\fBServices:\fR
+.IP \[bu] 2
+Exception logging via host logging facilities
+.IP \[bu]
+Remote file system access for Root PD components
+
+\fBNote:\fR
+It is recommended to run the root PD daemon if visibility of DSP
+exception logs from dynamic Protection Domains is required.
+
+
+.SS audiopd (Audio PD)
+.PP
+\fBUsage:\fR
+.nf
+adsprpcd audiopd adsp
+.fi
+
+.PP
+\fBPurpose:\fR
+Attaches to the Audio Protection Domain and serves reverse-RPC for audio
+workloads.
+
+Supports dynamic loading of audio modules and manages memory allocation
+requests originating from audio components.
+
+.PP
+\fBServices:\fR
+.IP \[bu] 2
+Dynamic memory allocation via RPC mechanisms
+.IP \[bu]
+Dynamic module loading for audio components
+
+.SS sensorspd (Sensors PD)
+.PP
+\fBUsage:\fR
+.nf
+adsprpcd sensorspd
+.fi
+
+.PP
+\fBPurpose:\fR
+Handles FastRPC requests originating from sensor DSP components and
+processed by a host-side daemon. Unlike typical FastRPC usage, Sensors PD supports 
+connections from multiple applications simultaneously rather than a one-to-one
+process mapping.
+
+\fBServices:\fR
+.IP \[bu] 2
+File system operations on behalf of sensor DSP components
+.IP \[bu]
+Dynamic loading of shared objects required by sensor workloads
+.IP \[bu]
+Handling of FastRPC requests from multiple client applications connected
+to Sensors PD
+
+.SH FILES
+.TP
+.I libadsp_default_listener.so
+Listener implementation for ADSP
+.TP
+.I libsdsp_default_listener.so
+Listener implementation for SDSP
+.TP
+.I libcdsp_default_listener.so
+Listener implementation for CDSP and GDSP
+
+.SH SEE ALSO
+.BR fastrpc (3)

--- a/Docs/manpages/fastrpc.3
+++ b/Docs/manpages/fastrpc.3
@@ -1,0 +1,172 @@
+.TH fastrpc 3 "May 2026" "fastrpc" "Library Functions"
+.SH NAME
+fastrpc \- Qualcomm FastRPC C API
+.SH SYNOPSIS
+.B #include <fastrpc/remote.h>
+.br
+.B #include <fastrpc/rpcmem.h>
+.br
+
+
+.SS Remote Handle Functions
+.B int remote_handle64_open(const char* name, remote_handle64 *ph);
+.br
+.B int remote_handle64_invoke(remote_handle64 h, uint32_t dwScalars, remote_arg *pra);
+.br
+.B int remote_handle64_invoke_async(remote_handle64 h, fastrpc_async_descriptor_t *desc, uint32_t dwScalars, remote_arg *pra);
+.br
+.B int remote_handle64_control(remote_handle64 h, uint32_t req, void* data, uint32_t datalen);
+.br
+.B int remote_handle64_close(remote_handle64 h);
+
+.SS RPC Memory Functions (rpcmem)
+.B void rpcmem_init(void);
+.br
+.B void rpcmem_deinit(void);
+.br
+.B void* rpcmem_alloc(int heapid, uint32_t flags, int size);
+.br
+.B void* rpcmem_alloc2(int heapid, uint32_t flags, size_t size);
+.br
+.B static inline void* rpcmem_alloc_def(int size);
+.br
+.B void rpcmem_free(void* po);
+.br
+.B int rpcmem_to_fd(void* po);
+
+.SS DSP Queue Functions (dspqueue_rpc)
+.B int dspqueue_rpc_open(const char* uri, remote_handle64* h);
+.br
+.B int dspqueue_rpc_close(remote_handle64 h);
+.br
+.B AEEResult dspqueue_rpc_init_process_state(remote_handle64 _h, int32_t process_state_fd);
+.br
+.B AEEResult dspqueue_rpc_create_queue(remote_handle64 _h, uint32_t id, int32_t queue_fd, uint32_t count, uint64_t* queue_id);
+.br
+.B AEEResult dspqueue_rpc_destroy_queue(remote_handle64 _h, uint64_t queue_id);
+.br
+.B AEEResult dspqueue_rpc_is_imported(remote_handle64 _h, uint64_t queue_id, int32_t* imported);
+.br
+.B AEEResult dspqueue_rpc_wait_signal(remote_handle64 _h, int32_t* signal);
+.br
+.B AEEResult dspqueue_rpc_cancel_wait_signal(remote_handle64 _h);
+.br
+.B AEEResult dspqueue_rpc_signal(remote_handle64 _h);
+
+.SH DESCRIPTION
+The
+.B fastRPC
+library provides mechanisms to offload execution of compute-intensive tasks from the Application Processor (CPU) to remote DSP domains (such as ADSP, CDSP, SDSP, and GDSP). It uses an IDL compiler to generate stub (CPU) and skel (DSP) code, which communicate via the APIs exposed in this header.
+
+.SS Remote Handle Functions
+.TP
+.B remote_handle64_open()
+Opens a multi-domain remote handle for a specific device or URI. The handle is stored in
+.I ph
+upon success.
+.TP
+.B remote_handle64_invoke()
+Invokes a remote procedure call synchronously on the DSP using the given handle
+.IR h .
+.I dwScalars
+specifies the signature of the arguments, and
+.I pra
+points to the array of arguments.
+.TP
+.B remote_handle64_invoke_async()
+Asynchronously invokes a remote procedure call on the DSP. The completion is tracked via the
+.I desc
+asynchronous descriptor.
+.TP
+.B remote_handle64_control()
+Sends a control request (such as getting the domain ID) to the DSP driver for an open handle.
+.TP
+.B remote_handle64_close()
+Closes an open remote handle and releases associated resources.
+
+.SS RPC Memory (rpcmem) Functions
+The
+.B rpcmem
+functions provide memory allocation routines that guarantee memory buffers are correctly mapped and contiguous, enabling zero-copy transfers between the CPU and DSP. Memory heaps are identified by an ID (e.g., \fBRPCMEM_HEAP_ID_SYSTEM\fR, \fBRPCMEM_HEAP_ID_CONTIG\fR) and constrained by flags (e.g., \fBRPCMEM_FLAG_UNCACHED\fR, \fBRPCMEM_FLAG_CACHED\fR, \fBRPCMEM_DEFAULT_FLAGS\fR).
+
+.TP
+.B rpcmem_init() / rpcmem_deinit()
+Initializes and deinitializes the RPC memory subsystem. If a client links with \fBlibadsprpc.so\fR, \fBlibcdsprpc.so\fR, or \fBlibsdsprpc.so\fR directly, the initialization is handled automatically.
+.TP
+.B rpcmem_alloc() / rpcmem_alloc2()
+Allocates RPC memory from a specific ION/DMA heap
+.IR heapid .
+.I flags
+specify caching and alignment constraints. Use
+.B rpcmem_alloc2()
+for allocations larger than 2 GB.
+.br
+Example: \fBrpcmem_alloc(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS, 4096);\fR
+.TP
+.B rpcmem_alloc_def()
+A convenience inline wrapper for allocating system heap memory using default cached flags.
+.TP
+.B rpcmem_free()
+Frees memory previously allocated by
+.B rpcmem_alloc()
+or
+.BR rpcmem_alloc2() .
+.TP
+.B rpcmem_to_fd()
+Retrieves the file descriptor (FD) underlying an RPC memory allocation. This is useful for passing the buffer directly to other sub-systems (like DMA-BUF).
+
+.SS DSP Queue (dspqueue_rpc) Functions
+The
+.B dspqueue_rpc
+API allows the setup and management of shared DSP queues, enabling highly efficient, stateful asynchronous communication and signaling.
+.TP
+.B dspqueue_rpc_open()
+Opens a fastRPC connection to the DSP queue interface using the specified
+.I uri
+(e.g., "file:///libdspqueue_rpc_skel.so?dspqueue_rpc_skel_handle_invoke&_modver=1.0").
+.TP
+.B dspqueue_rpc_close()
+Closes the given DSP queue handle
+.IR h .
+.TP
+.B dspqueue_rpc_init_process_state()
+Initializes the overall process state on the DSP utilizing the provided
+.IR process_state_fd .
+.TP
+.B dspqueue_rpc_create_queue()
+Creates a shared communication queue on the remote DSP bound to the given memory file descriptor
+.I queue_fd
+and
+.IR count .
+Outputs the identifier into
+.IR queue_id .
+.TP
+.B dspqueue_rpc_destroy_queue()
+Destroys and reclaims a previously created remote queue matching
+.IR queue_id .
+.TP
+.B dspqueue_rpc_is_imported()
+Verifies if a specific
+.I queue_id
+has been successfully imported by the DSP side.
+.TP
+.B dspqueue_rpc_wait_signal()
+Blocks and waits for a remote queue signal to be emitted by the DSP.
+.TP
+.B dspqueue_rpc_cancel_wait_signal()
+Cancels a pending wait signal operation on the remote handle.
+.TP
+.B dspqueue_rpc_signal()
+Fires a signal event from the CPU to awake the associated DSP queue loop.
+
+.SH RETURN VALUE
+On success, handle functions and most
+.B dspqueue
+functions return \fB0\fR (\fBAEE_SUCCESS\fR). On error, they return a non-zero error code. 
+.B rpcmem_alloc()
+and its variants return a valid pointer on success, or \fBNULL\fR on failure.
+
+
+.SH SEE ALSO
+.BR dsprpcd (8)
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS = inc src test files
+SUBDIRS = inc src test files Docs/manpages
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -177,5 +177,6 @@ inc/Makefile
 src/Makefile
 test/Makefile
 files/Makefile
+Docs/manpages/Makefile
 ])
 AC_OUTPUT


### PR DESCRIPTION
Distributions such as Debian require manual pages for installed binaries. The FastRPC daemons currently do not have associated documentation.

Provide manual pages for the FastRPC user API and daemon interfaces. Use a single daemon manual page for the various DSP daemon names and install the appropriate aliases during installation so the documentation remains consistent across compatibility entry points.

Fixes: #229
Related to: #321
CRs-Fixed: 4600851