### PR TITLE
build: fix distcheck failure caused by absolute sysusers/udev paths

### DIFF
--- a/.github/workflows/build_linux_gnu.yml
+++ b/.github/workflows/build_linux_gnu.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Compile code for LE platform
       run: |
         GITCOMPILE_NO_MAKE=true ./gitcompile --enable-stricter
-        make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-systemdsystemunitdir='lib/systemd/system' --enable-stricter"
+        make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-systemdsystemunitdir='lib/systemd/system' --with-udevrulesdir='lib/udev/rules.d' --with-sysusersdir='lib/sysusers.d' --enable-stricter"


### PR DESCRIPTION
## Fix `distcheck` failures caused by absolute sysusers/udev paths

### Problem
- `make distcheck` failed because `sysusersdir` and `udevrulesdir` default to absolute system paths:
  - `/usr/lib/sysusers.d`
  - `/usr/lib/udev/rules.d`
- The `distcheck` environment is unprivileged and cannot install files into these locations.

### Solution
- Add `--with-sysusersdir` and `--with-udevrulesdir` to `DISTCHECK_CONFIGURE_FLAGS`.
- Configure both directories to use relative paths within the build tree instead of system locations.

### Result
- Prevents installation attempts to protected system directories during `distcheck`.
- Aligns with the existing `systemdsystemunitdir` override.
- Allows `make distcheck` to complete successfully in isolated build environments.