### PR TITLE
Add missing input validation in remote API entry points

### DIFF
--- a/src/fastrpc_apps_user.c
+++ b/src/fastrpc_apps_user.c
@@ -2793,8 +2793,8 @@ int remote_session_control(uint32_t req, void *data, uint32_t datalen) {
     VERIFYC(IS_VALID_DOMAIN_ID(domain), AEE_EBADPARM);
     VERIFYC(rpc_uri->module_uri != NULL && rpc_uri->module_uri_len > 0,
             AEE_EBADPARM);
-    VERIFYC(rpc_uri->uri != NULL && rpc_uri->uri_len > rpc_uri->module_uri_len,
-            AEE_EBADPARM);
+    VERIFYC(rpc_uri->uri != NULL, AEE_EBADPARM);
+    VERIFYC(rpc_uri->uri_len > rpc_uri->module_uri_len, AEE_EBADSIZE);
     ret_val = snprintf(0, 0, "%s%s%s%s%d", rpc_uri->module_uri,
                        FASTRPC_DOMAIN_URI, SUBSYSTEM_NAME[domain],
                        FASTRPC_SESSION_URI, rpc_uri->session_id);

--- a/src/fastrpc_mem.c
+++ b/src/fastrpc_mem.c
@@ -932,6 +932,7 @@ int remote_munmap64(uint64_t vaddrout, int64_t size) {
 
   VERIFY(AEE_SUCCESS == (nErr = fastrpc_init_once()));
 
+  VERIFYC(size > 0, AEE_EBADPARM);
   domain = get_current_domain();
   VERIFYC(IS_VALID_EFFECTIVE_DOMAIN_ID(domain), AEE_ERPC);
 


### PR DESCRIPTION
- FASTRPC_GET_URI: split combined uri/uri_len check so an insufficient output buffer returns AEE_EBADSIZE instead of AEE_EBADPARM
- remote_munmap64: reject zero and negative size with AEE_EBADPARM before the value reaches the kernel ioctl; remote_munmap inherits this via its int64_t cast and delegation

CRs-Fixed: 4597612