### PR TITLE
fastrpc: config_parser: suppress per-file DSP_LIBRARY_PATH warning

### DIFF
--- a/src/fastrpc_config_parser.c
+++ b/src/fastrpc_config_parser.c
@@ -80,17 +80,15 @@ static void get_dsp_lib_path(const char *machine_name, const char *filepath, cha
         if (!in_machines && strcmp(value, "machines") == 0) {
           in_machines = 1;
         } else if (in_machines && !in_target_machine) {
-          // This is a machine name key
           strlcpy(current_machine, value, sizeof(current_machine));
           if (strcmp(current_machine, machine_name) == 0) {
             in_target_machine = 1;
           }
         } else if (in_target_machine && strcmp(value, DSP_LIB_KEY) == 0) {
-          // Next scalar will be the DSP_LIBRARY_PATH value
           yaml_event_delete(&event);
           if (yaml_parser_parse(&parser, &event) && event.type == YAML_SCALAR_EVENT) {
             strlcpy(dsp_lib_paths, (const char *)event.data.scalar.value, PATH_MAX);
-			FARF(ALWAYS, "dsp_lib_paths is %s", dsp_lib_paths);
+            FARF(ALWAYS, "dsp_lib_paths is %s", dsp_lib_paths);
             found_dsp_path = 1;
             done = 1;
           }
@@ -99,7 +97,6 @@ static void get_dsp_lib_path(const char *machine_name, const char *filepath, cha
       }
       case YAML_MAPPING_END_EVENT:
         if (in_target_machine) {
-          // Exiting the target machine mapping
           in_target_machine = 0;
           if (found_dsp_path) {
             done = 1;
@@ -118,11 +115,6 @@ static void get_dsp_lib_path(const char *machine_name, const char *filepath, cha
 
   yaml_parser_delete(&parser);
   fclose(file);
-
-  if (!found_dsp_path) {
-    FARF(ALWAYS, "Warning: DSP_LIBRARY_PATH not found for machine [%s] in configuration file %s\n", 
-         machine_name, filepath);
-  }
 }
 
 static void parse_config_dir(char *machine_name) {


### PR DESCRIPTION
On a system with multiple YAML files under conf.d/, the daemon emits a DSP_LIBRARY_PATH not found warning for every file that does not contain an entry for the running machine. With 17+ YAML files installed, this floods journalctl with noise on every daemon startup.

Root cause: get_dsp_lib_path() emitted a warning whenever the target machine name was not found in a given file. parse_config_dir() called it for every YAML file unconditionally, so a warning was printed for each file that legitimately belongs to a different board.

Fix: Remove the per-file warning from get_dsp_lib_path(). Read every YAML file in conf.d/ unconditionally so that all target configurations are checked. On a single root filesystem supporting multiple targets, each target has its own YAML file and all must be scanned to find the matching machine. The existing summary warning for no match across all files is preserved, giving exactly one diagnostic when something is genuinely wrong.

Fixes: #322 
CRs-Fixed: 4604037